### PR TITLE
hotfix: Исправление отображение блоков

### DIFF
--- a/app/features/bestiary/body/CreatureBody.vue
+++ b/app/features/bestiary/body/CreatureBody.vue
@@ -135,7 +135,7 @@
           </UiCollapse>
         </template>
 
-        <template v-if="creature.legendary.count > 0">
+        <template v-if="creature.legendary?.actions?.length">
           <UiCollapse default-open>
             <template #default> Легендарные действия </template>
 


### PR DESCRIPTION
Убрано отображение блока легендарных действий, если нет самих действий.
Исправлено отображение секцкии если она отсуствует.