### PR TITLE
ci: migrate deployment scheme to Dokploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
 name: Deploy
-run-name: Deploy by @${{ github.actor }}
+run-name: Deploy ${{ github.ref_name }} by @${{ github.actor }}
 
 on:
   push:
@@ -9,12 +9,13 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY: ghcr.io
+  REGISTRY: ${{ secrets.REGISTRY_URL }}
 
 jobs:
   build:
-    name: Build Docker Image
+    name: Build & Push Docker Image
     runs-on: ubuntu-latest
+    if: ${{ github.ref_name == 'main' || github.ref_name == 'dev' }}
     concurrency:
       group: build-${{ github.ref_name }}
       cancel-in-progress: true
@@ -23,77 +24,89 @@ jobs:
       packages: write
       attestations: write
       id-token: write
+    outputs:
+      image_tag: ${{ steps.meta.outputs.version }}
+      image_name: ${{ steps.set_image_name.outputs.IMAGE_NAME }}
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      - uses: docker/setup-buildx-action@v3
+      - name: Set lowercase image name
+        id: set_image_name
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          LOWER_NAME=$(echo "$REPO_NAME" | tr '[:upper:]' '[:lower:]')
+          echo "IMAGE_NAME=$LOWER_NAME" >> $GITHUB_ENV
+          echo "IMAGE_NAME=$LOWER_NAME" >> $GITHUB_OUTPUT
 
-      - uses: docker/login-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
-      - uses: docker/metadata-action@v5
+      - name: Extract Docker metadata
+        uses: docker/metadata-action@v5
         id: meta
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch,enabled=true
-            type=raw,value=latest,enabled=${{ github.ref_name == 'main' }}
-          labels: |
-            org.opencontainers.image.title=${{ github.repository }}
-            org.opencontainers.image.vendor=${{ github.repository_owner }}
-            org.opencontainers.image.created=${{ github.event.repository.updated_at }}
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ github.sha }}
+            type=sha,prefix=${{ github.ref_name == 'main' && 'release-' || 'dev-' }},format=short
 
-      - uses: docker/build-push-action@v6
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
         id: push
         with:
           context: .
-          file: ./Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: |
-            type=gha,scope=buildkit-${{ github.ref_name }}
-            type=gha,scope=buildkit-main
-          cache-to: type=gha,mode=max,scope=buildkit-${{ github.ref_name }}
+          cache-from: type=gha,scope=${{ github.ref_name }}
+          cache-to: type=gha,mode=min,scope=${{ github.ref_name }}
 
-
-      - uses: actions/attest-build-provenance@v3
+      - name: Generate SLSA provenance
+        uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ github.repository }}
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.5.0
+
+      - name: Sign image
+        run: |
+          cosign sign --yes \
+          "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}@${{ steps.push.outputs.digest }}"
 
   update:
     name: Update Server
     needs: build
     runs-on: ubuntu-latest
+    if: ${{ github.ref_name == 'main' || github.ref_name == 'dev' }}
     concurrency:
       group: update-${{ github.ref_name == 'main' && 'prod' || 'dev' }}-server
       cancel-in-progress: false
     env:
-      SERVICE_NAME: 5e24-${{ github.ref_name == 'main' && 'prod' || 'dev' }}-app
-      CONFIG_FILE: ${{ secrets.BEGET_SSH_PATH }}/${{ github.ref_name == 'main' && 'prod' || 'dev' }}/5e24/compose.yaml
+      APP_ID: ${{ github.ref_name == 'main' && secrets.DOKPLOY_APP_ID_PROD || secrets.DOKPLOY_APP_ID_DEV }}
+      IMAGE_NAME: ${{ needs.build.outputs.image_name }}
     steps:
-      - uses: appleboy/ssh-action@master
+      - name: Dokploy Update Image
+        uses: jegork/dokploy-update-image-action@0.1.0
         with:
-          host: ${{ secrets.BEGET_SSH_HOST }}
-          username: ${{ secrets.BEGET_SSH_USER }}
-          key: ${{ secrets.BEGET_SSH_KEY }}
-          port: ${{ secrets.BEGET_SSH_PORT }}
-          script: |
-            docker compose -f ${{ env.CONFIG_FILE }} pull ${{ env.SERVICE_NAME }} && \
-            docker compose -f ${{ env.CONFIG_FILE }} up ${{ env.SERVICE_NAME }} \
-              --no-deps \
-              --detach \
-              --wait \
-              --wait-timeout 60
-            
-            DANGLING=$(docker images --filter "dangling=true" -q --no-trunc)
-            if [ -n "$DANGLING" ]; then
-              docker rmi $DANGLING || true
-            fi
+          base_url: ${{ secrets.DOKPLOY_URL }}
+          token: ${{ secrets.DOKPLOY_API_KEY }}
+          application_id: ${{ env.APP_ID }}
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build.outputs.image_tag }}
+
+      - name: Dokploy Deployment
+        uses: benbristow/dokploy-deploy-action@0.2.2
+        with:
+          api_token: ${{ secrets.DOKPLOY_API_KEY }}
+          application_id: ${{ env.APP_ID }}
+          dokploy_url: ${{ secrets.DOKPLOY_URL }}
+          service_type: application


### PR DESCRIPTION
  Changes:
   - Pipeline: Switched docker-deploy.yml to Dokploy actions.
   - Registry: Configured private registry push with dynamic image naming.
   - Security: Added SLSA build provenance and optimized GHA permissions.
   - Automation: Integrated automatic image updates and service redeployment via Dokploy API.

  Note: Requires DOKPLOY_* and REGISTRY_* secrets to be configured in the repository.
