### PR TITLE
fix(ui): исправление бесконечного скролла в широком режиме и обновление иконок

### DIFF
--- a/app/features/infrastructure/sidebar/display-settings/constants.ts
+++ b/app/features/infrastructure/sidebar/display-settings/constants.ts
@@ -22,13 +22,13 @@ export const LAYOUT_WIDTH_OPTIONS = [
   {
     value: LayoutWidthName.Default,
     label: 'Обычная',
-    icon: 'tabler:columns',
+    icon: 'tabler:layout-sidebar-right-expand',
     title: 'Обычная ширина',
   },
   {
     value: LayoutWidthName.Wide,
     label: 'Широкая',
-    icon: 'tabler:columns-3',
+    icon: 'tabler:columns-2',
     title: 'Широкая ширина',
   },
 ] as const;

--- a/app/pages/bestiary/index.vue
+++ b/app/pages/bestiary/index.vue
@@ -244,17 +244,51 @@
   });
 
   // Динамический таргет для бесконечного скролла
-  const infiniteScrollTarget = computed(() => {
-    if (!import.meta.client) {
-      return null;
+  // В стандартном режиме — window с большим distance (900px),
+  // в Wide Mode — контейнер списка с малым distance (200px),
+  // т.к. контейнер сам по себе ~900px высотой.
+  const windowScrollTarget = computed(() =>
+    import.meta.client && !isSplitActive.value ? window : null,
+  );
+
+  const splitScrollTarget = shallowRef<HTMLElement | null>(null);
+
+  /**
+   * Поиск DOM-контейнера для скролла в Wide Mode.
+   * Использует requestAnimationFrame для повторной попытки,
+   * т.к. элемент может ещё не быть в DOM при первом вызове.
+   */
+  function resolveSplitContainer(): void {
+    const container = document.getElementById('section-list-container');
+
+    if (container) {
+      splitScrollTarget.value = container;
+
+      return;
     }
 
-    if (isSplitActive.value) {
-      return document.getElementById('section-list-container');
-    }
+    requestAnimationFrame(() => {
+      splitScrollTarget.value = document.getElementById(
+        'section-list-container',
+      );
+    });
+  }
 
-    return window;
-  });
+  if (import.meta.client) {
+    onMounted(() => {
+      watch(
+        isSplitActive,
+        (active) => {
+          if (active) {
+            resolveSplitContainer();
+          } else {
+            splitScrollTarget.value = null;
+          }
+        },
+        { immediate: true },
+      );
+    });
+  }
 
   const listResetKey = computed(() =>
     JSON.stringify({
@@ -429,8 +463,13 @@
     }
   }
 
-  useInfiniteScroll(infiniteScrollTarget, loadNextCreaturePage, {
+  useInfiniteScroll(windowScrollTarget, loadNextCreaturePage, {
     distance: BESTIARY_LIST_LOAD_MORE_DISTANCE,
+    canLoadMore: () => hasNextPage.value && !isLoadingMore.value,
+  });
+
+  useInfiniteScroll(splitScrollTarget, loadNextCreaturePage, {
+    distance: 200,
     canLoadMore: () => hasNextPage.value && !isLoadingMore.value,
   });
 

--- a/app/pages/spells/index.vue
+++ b/app/pages/spells/index.vue
@@ -244,17 +244,51 @@
   });
 
   // Динамический таргет для бесконечного скролла
-  const infiniteScrollTarget = computed(() => {
-    if (!import.meta.client) {
-      return null;
+  // В стандартном режиме — window с большим distance (900px),
+  // в Wide Mode — контейнер списка с малым distance (200px),
+  // т.к. контейнер сам по себе ~900px высотой.
+  const windowScrollTarget = computed(() =>
+    import.meta.client && !isSplitActive.value ? window : null,
+  );
+
+  const splitScrollTarget = shallowRef<HTMLElement | null>(null);
+
+  /**
+   * Поиск DOM-контейнера для скролла в Wide Mode.
+   * Использует requestAnimationFrame для повторной попытки,
+   * т.к. элемент может ещё не быть в DOM при первом вызове.
+   */
+  function resolveSplitContainer(): void {
+    const container = document.getElementById('section-list-container');
+
+    if (container) {
+      splitScrollTarget.value = container;
+
+      return;
     }
 
-    if (isSplitActive.value) {
-      return document.getElementById('section-list-container');
-    }
+    requestAnimationFrame(() => {
+      splitScrollTarget.value = document.getElementById(
+        'section-list-container',
+      );
+    });
+  }
 
-    return window;
-  });
+  if (import.meta.client) {
+    onMounted(() => {
+      watch(
+        isSplitActive,
+        (active) => {
+          if (active) {
+            resolveSplitContainer();
+          } else {
+            splitScrollTarget.value = null;
+          }
+        },
+        { immediate: true },
+      );
+    });
+  }
 
   const listResetKey = computed(() =>
     JSON.stringify({
@@ -413,8 +447,13 @@
     }
   }
 
-  useInfiniteScroll(infiniteScrollTarget, loadNextSpellPage, {
+  useInfiniteScroll(windowScrollTarget, loadNextSpellPage, {
     distance: SPELL_LIST_LOAD_MORE_DISTANCE,
+    canLoadMore: () => hasNextPage.value && !isLoadingMore.value,
+  });
+
+  useInfiniteScroll(splitScrollTarget, loadNextSpellPage, {
+    distance: 200,
     canLoadMore: () => hasNextPage.value && !isLoadingMore.value,
   });
 

--- a/app/shared/ui/grouped-list/GroupedList.vue
+++ b/app/shared/ui/grouped-list/GroupedList.vue
@@ -117,6 +117,8 @@
 
   const isScrollPositionRestored = ref(false);
 
+  const { isSplitActive } = useLayoutWidth();
+
   /**
    * Разбивает элементы на строки виртуальной сетки.
    */
@@ -514,13 +516,45 @@
     );
   }
 
-  const scrollContainer = computed(() => {
-    if (!import.meta.client) {
-      return null;
+  const scrollContainer = shallowRef<HTMLElement | Window | null>(
+    import.meta.client ? window : null,
+  );
+
+  /**
+   * Поиск DOM-контейнера для скролла в Wide Mode.
+   * Использует requestAnimationFrame для повторной попытки,
+   * т.к. элемент может ещё не быть в DOM при первом вызове.
+   */
+  function resolveSplitContainer(): void {
+    const container = document.getElementById('section-list-container');
+
+    if (container) {
+      scrollContainer.value = container;
+
+      return;
     }
 
-    return document.getElementById('section-list-container') || window;
-  });
+    requestAnimationFrame(() => {
+      scrollContainer.value =
+        document.getElementById('section-list-container') ?? window;
+    });
+  }
+
+  if (import.meta.client) {
+    onMounted(() => {
+      watch(
+        isSplitActive,
+        (active) => {
+          if (active) {
+            resolveSplitContainer();
+          } else {
+            scrollContainer.value = window;
+          }
+        },
+        { immediate: true },
+      );
+    });
+  }
 
   /**
    * Выполняет прокрутку списка к указанному элементу.


### PR DESCRIPTION
- Внедрен раздельный механизм useInfiniteScroll для стандартного (window) и широкого (container-scroll) режимов в разделах Бестиария и Заклинаний. Это решило проблему, когда скролл не срабатывал или срабатывал постоянно из-за некорректного расстояния distance (для контейнера установлено 200px вместо 900px).

- Внедрен поиск контейнера #section-list-container с повторной попыткой через requestAnimationFrame на событии onMounted, что исключает ситуацию, когда элемент еще отсутствует в DOM при рендере страницы.

- В GroupedList.vue переделан scrollContainer с реактивного computed на shallowRef с отслеживанием isSplitActive и безопасным поиском DOM-элементов.

- Изменены иконки ширины макета в настройках отображения (DisplaySettings):

  * «Обычная» изменена с tabler:columns на tabler:layout-sidebar-right-expand

  * «Широкая» изменена с tabler:columns-3 на tabler:columns-2