### PR TITLE
fix: исправление навигации по подклассам и сохранение выделения элементов в сплит-режиме

### DIFF
--- a/app/composables/useSectionDetail.ts
+++ b/app/composables/useSectionDetail.ts
@@ -7,13 +7,19 @@ import { FetchStatus } from '~/shared/consts';
 import { createLruCache } from '~/utils/createLruCache';
 import { getOrigin } from '~/utils/getOrigin';
 
-export interface UseSectionDetailOptions {
+export interface UseSectionDetailOptions<TDetail = unknown> {
   /** Базовый путь раздела (например, '/classes') */
   sectionPath: string;
   /** Базовый путь API для загрузки сущности (например, '/api/v2/classes') */
   apiBasePath: string;
   /** Список элементов раздела для автоматического выбора первого */
   items: Ref<Array<{ url: string }> | null | undefined>;
+  /**
+   * Извлекает URL родительского элемента из детальных данных.
+   * Используется для сохранения выделения основного элемента в списке
+   * при выборе дочернего (например, подкласса).
+   */
+  getParentUrl?: (detail: TDetail) => string | undefined;
 }
 
 export interface UseSectionDetailReturn<TDetail> {
@@ -46,11 +52,16 @@ export interface UseSectionDetailReturn<TDetail> {
  * @returns Набор реактивных переменных и методов для управления детальной панелью.
  */
 export function useSectionDetail<TDetail>(
-  options: UseSectionDetailOptions,
+  options: UseSectionDetailOptions<TDetail>,
 ): UseSectionDetailReturn<TDetail> {
   const route = useRoute();
   const router = useRouter();
   const { isSplitActive } = useLayoutWidth();
+
+  const detailParentUrl = useState<string | undefined>(
+    'section-detail-parent-url',
+    () => undefined,
+  );
 
   const detailCache = createLruCache<string, TDetail>(50);
 
@@ -111,6 +122,11 @@ export function useSectionDetail<TDetail>(
     },
     { immediate: true },
   );
+
+  watch(detailData, (detail) => {
+    detailParentUrl.value =
+      detail && options.getParentUrl ? options.getParentUrl(detail) : undefined;
+  });
 
   const isDetailLoading = computed(
     () => detailStatus.value === FetchStatus.Pending,

--- a/app/composables/useSectionLink.ts
+++ b/app/composables/useSectionLink.ts
@@ -17,9 +17,16 @@ export function useSectionLink(
   const { isSplitActive } = useLayoutWidth();
   const overlay = useOverlay();
 
+  const detailParentUrl = useState<string | undefined>(
+    'section-detail-parent-url',
+    () => undefined,
+  );
+
   const isOpened = computed(() => {
     if (isSplitActive.value) {
-      return route.query.detail === itemUrl;
+      return (
+        route.query.detail === itemUrl || detailParentUrl.value === itemUrl
+      );
     }
 
     if (import.meta.server) {

--- a/app/features/classes/body/ClassBody.vue
+++ b/app/features/classes/body/ClassBody.vue
@@ -83,6 +83,7 @@
             :has-description="!!detail.description"
             :has-spells="detail.casterType !== 'NONE'"
             :navigate-in-place="navigateInPlace"
+            :in-split="inSplit"
             @navigate="emit('navigate', $event)"
           />
 

--- a/app/features/classes/body/ui/ClassRouting.vue
+++ b/app/features/classes/body/ui/ClassRouting.vue
@@ -16,6 +16,7 @@
     parent = undefined,
     hasSpells = false,
     navigateInPlace = false,
+    inSplit = false,
   } = defineProps<{
     url: string;
     name: NameResponse;
@@ -27,6 +28,10 @@
      * внутри текущего контейнера (drawer) без перехода на отдельную страницу.
      */
     navigateInPlace?: boolean;
+    /**
+     * Отображается в сплит-панели — навигация обновляет query.detail.
+     */
+    inSplit?: boolean;
   }>();
 
   const emit = defineEmits<{
@@ -61,16 +66,35 @@
     destroyOnClose: true,
   });
 
+  const route = useRoute();
+  const router = useRouter();
+
   /** Ссылка на popover для программного закрытия после выбора подкласса */
   const popoverOpen = ref(false);
 
+  /** Навигация изолирована от основного роутера (drawer или split) */
+  const isInlineNavigation = computed(() => navigateInPlace || inSplit);
+
   /**
    * Обработчик выбора подкласса из CommandPalette.
-   * При navigateInPlace переключает содержимое inline,
-   * иначе навигирует стандартным роутером.
+   * В drawer — переключает содержимое inline.
+   * В сплит-режиме — обновляет query.detail.
+   * В обычном режиме — навигирует стандартным роутером.
    */
   function handleSubclassSelect(subclassUrl: string): void {
     popoverOpen.value = false;
+
+    if (inSplit) {
+      router.push({
+        query: {
+          ...route.query,
+          detail: subclassUrl,
+        },
+      });
+
+      return;
+    }
+
     emit('navigate', subclassUrl);
   }
 
@@ -78,7 +102,20 @@
    * Обработчик клика по кнопке «Класс» — возврат к основному классу.
    */
   function handleClassClick(): void {
-    emit('navigate', parent ? parent.url : url);
+    const classUrl = parent ? parent.url : url;
+
+    if (inSplit) {
+      router.push({
+        query: {
+          ...route.query,
+          detail: classUrl,
+        },
+      });
+
+      return;
+    }
+
+    emit('navigate', classUrl);
   }
 
   /** Прокрутка к блоку описания внутри текущего контейнера */
@@ -107,7 +144,7 @@
           label: subclass.name.rus,
           suffix: subclass.name.eng ? `[${subclass.name.eng}]` : undefined,
           source: subclass.source,
-          ...(navigateInPlace
+          ...(isInlineNavigation.value
             ? { onSelect: () => handleSubclassSelect(subclass.url) }
             : { to: `/classes/${subclass.url}` }),
         })),
@@ -119,12 +156,12 @@
   <div class="flex w-auto flex-wrap gap-2">
     <UButton
       :to="
-        navigateInPlace ? undefined : `/classes/${parent ? parent.url : url}`
+        isInlineNavigation ? undefined : `/classes/${parent ? parent.url : url}`
       "
       variant="soft"
       color="secondary"
       size="md"
-      @click.left.exact.prevent="navigateInPlace && handleClassClick()"
+      @click.left.exact.prevent="isInlineNavigation && handleClassClick()"
     >
       <div class="flex flex-col items-start leading-tight">
         <span class="text-xs text-secondary"> Класс: </span>

--- a/app/pages/classes/index.vue
+++ b/app/pages/classes/index.vue
@@ -58,6 +58,7 @@
     sectionPath: '/classes',
     apiBasePath: '/api/v2/classes',
     items: classes,
+    getParentUrl: (detail) => detail.parent?.url,
   });
 </script>
 

--- a/app/pages/species/index.vue
+++ b/app/pages/species/index.vue
@@ -57,6 +57,7 @@
     sectionPath: '/species',
     apiBasePath: '/api/v2/species',
     items: data,
+    getParentUrl: (detail) => detail.parent?.url ?? detail.species?.url,
   });
 </script>
 


### PR DESCRIPTION
Реализовано корректное поведение интерфейса в режиме разделенного экрана (сплит-панели/во всю ширину) при переходе между основными сущностями и их дочерними элементами (подклассы, подрасы).

Основные изменения:

Исправлена полная перезагрузка страницы при выборе подкласса в сплит-режиме:

В компонент ClassRouting добавлен проп inSplit.
Внедрена логика isInlineNavigation (активна при открытии в drawer или в сплит-режиме).
При выборе подкласса или возврате к родительскому классу в сплит-режиме теперь обновляется параметр query.detail в URL через стандартный роутер без перезагрузки страницы.
Добавлено сохранение выделения родительского элемента в боковом списке при просмотре подкласса или подрасы:

В коcomposable useSectionDetail добавлена опция getParentUrl и реактивное состояние detailParentUrl, хранящее ссылку на родителя текущей открытой сущности.
В useSectionLink доработано определение активного состояния (isOpened): элемент списка подсвечивается как активный, если его URL совпадает с query.detail либо с detailParentUrl.
На страницах классов (app/pages/classes/index.vue) и рас/видов (app/pages/species/index.vue) в вызов useSectionDetail передана функция getParentUrl для извлечения связи с родителем.