### PR TITLE
fix: редирект ?detail= -> /path в стандартном режиме для разделов спр…

### DIFF
--- a/app/pages/backgrounds/index.vue
+++ b/app/pages/backgrounds/index.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
-  import type { FetchStatusValue } from '~/shared/consts';
   import type {
     BackgroundDetailResponse,
     BackgroundLinkResponse,
   } from '~backgrounds/model';
 
-  import { FetchStatus } from '~/shared/consts';
   import { BackgroundBody } from '~backgrounds/body';
   import { BackgroundLink } from '~backgrounds/link';
   import { FilterControls, useFilter } from '~infrastructure/filter';
@@ -18,11 +16,6 @@
     title: 'Предыстории [Backgrounds]',
     description: 'Предыстории из D&D 5 (редакция 2024 года).',
   });
-
-  const { isSplitActive } = useLayoutWidth();
-
-  const route = useRoute();
-  const router = useRouter();
 
   const {
     filter,
@@ -54,177 +47,19 @@
     },
   );
 
-  const backgroundCache = createLruCache<string, BackgroundDetailResponse>(50);
-
-  const detailUrl = computed(() => {
-    const detail = route.query.detail;
-
-    return typeof detail === 'string' && detail ? detail : '';
-  });
-
-  const detailBackground = ref<BackgroundDetailResponse | null>(null);
-  const detailStatus = ref<FetchStatusValue>(FetchStatus.Idle);
-
-  /**
-   * Загрузка детальных данных предыстории по URL.
-   * @param url Идентификатор предыстории.
-   */
-  async function fetchBackgroundDetail(url: string): Promise<void> {
-    if (!url) {
-      detailBackground.value = null;
-      detailStatus.value = FetchStatus.Idle;
-
-      return;
-    }
-
-    if (backgroundCache.has(url)) {
-      detailBackground.value = backgroundCache.get(url) || null;
-      detailStatus.value = FetchStatus.Success;
-
-      return;
-    }
-
-    detailStatus.value = FetchStatus.Pending;
-
-    try {
-      const response = await $fetch<BackgroundDetailResponse>(
-        `/api/v2/backgrounds/${url}`,
-      );
-
-      backgroundCache.set(url, response);
-      detailBackground.value = response;
-      detailStatus.value = FetchStatus.Success;
-    } catch {
-      detailBackground.value = null;
-      detailStatus.value = FetchStatus.Error;
-    }
-  }
-
-  const isDetailDismissed = ref(false);
-  const isRouterReady = ref(false);
-
-  watch(
+  const {
     detailUrl,
-    (url) => {
-      if (url) {
-        isDetailDismissed.value = false;
-      }
-
-      fetchBackgroundDetail(url);
-    },
-    { immediate: true },
-  );
-
-  const isDetailLoading = computed(
-    () => detailStatus.value === FetchStatus.Pending,
-  );
-
-  const isDetailError = computed(
-    () => detailStatus.value === FetchStatus.Error,
-  );
-
-  const detailUrlForCopy = computed(() =>
-    detailUrl.value
-      ? `${getOrigin()}/backgrounds/${detailUrl.value}`
-      : undefined,
-  );
-
-  const detailEditUrl = computed(() =>
-    detailUrl.value ? `/workshop/backgrounds/${detailUrl.value}` : undefined,
-  );
-
-  watch([isSplitActive, detailUrl], ([splitActive, urlVal]) => {
-    if (isRouterReady.value && !splitActive && urlVal) {
-      navigateTo({
-        name: 'backgrounds-url',
-        params: { url: urlVal },
-      });
-
-      router.replace({
-        query: {
-          ...route.query,
-          detail: undefined,
-        },
-      });
-    }
-  });
-
-  /**
-   * Автоматический выбор первой предыстории в списке.
-   */
-  function autoSelectFirstBackground() {
-    if (!isSplitActive.value || isDetailDismissed.value) {
-      return;
-    }
-
-    const firstBackground = backgrounds.value?.[0];
-
-    if (firstBackground && !route.query.detail) {
-      router.replace({
-        query: {
-          ...route.query,
-          detail: firstBackground.url,
-        },
-      });
-    }
-  }
-
-  onMounted(async () => {
-    await router.isReady();
-    isRouterReady.value = true;
-
-    if (!isSplitActive.value && detailUrl.value) {
-      navigateTo({
-        name: 'backgrounds-url',
-        params: { url: detailUrl.value },
-      });
-
-      router.replace({
-        query: {
-          ...route.query,
-          detail: undefined,
-        },
-      });
-
-      return;
-    }
-
-    autoSelectFirstBackground();
-  });
-
-  watch([backgrounds, isSplitActive], () => {
-    if (isRouterReady.value) {
-      autoSelectFirstBackground();
-    }
-  });
-
-  /**
-   * Закрытие детальной панели.
-   */
-  function handleCloseDetail() {
-    isDetailDismissed.value = true;
-
-    router.push({
-      query: {
-        ...route.query,
-        detail: undefined,
-      },
-    });
-  }
-
-  useHead(() => {
-    if (isSplitActive.value && detailUrl.value) {
-      return {
-        link: [
-          {
-            rel: 'canonical',
-            href: `${getOrigin()}/backgrounds/${detailUrl.value}`,
-          },
-        ],
-      };
-    }
-
-    return {};
+    detailData: detailBackground,
+    isDetailLoading,
+    isDetailError,
+    isDetailDismissed,
+    detailUrlForCopy,
+    detailEditUrl,
+    handleCloseDetail,
+  } = useSectionDetail<BackgroundDetailResponse>({
+    sectionPath: '/backgrounds',
+    apiBasePath: '/api/v2/backgrounds',
+    items: backgrounds,
   });
 </script>
 

--- a/app/pages/feats/index.vue
+++ b/app/pages/feats/index.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
-  import type { FetchStatusValue } from '~/shared/consts';
   import type { FeatDetailResponse, FeatLinkResponse } from '~feats/model';
 
-  import { FetchStatus } from '~/shared/consts';
   import { FeatBody } from '~feats/body';
   import { FeatLink } from '~feats/link';
   import { FilterControls, useFilter } from '~infrastructure/filter';
@@ -15,11 +13,6 @@
     title: 'Черты [Feats]',
     description: 'Черты из D&D 5 (редакция 2024 года).',
   });
-
-  const { isSplitActive } = useLayoutWidth();
-
-  const route = useRoute();
-  const router = useRouter();
 
   const {
     filter,
@@ -51,175 +44,19 @@
     },
   );
 
-  // Локальный LRU-кэш для детальной информации о чертах
-  const featCache = createLruCache<string, FeatDetailResponse>(50);
-
-  // Вычисляем выбранный URL черты из query-параметров
-  const detailUrl = computed(() => {
-    const detail = route.query.detail;
-
-    return typeof detail === 'string' && detail ? detail : '';
-  });
-
-  const detailFeat = ref<FeatDetailResponse | null>(null);
-  const detailStatus = ref<FetchStatusValue>(FetchStatus.Idle);
-
-  /**
-   * Загрузка детальных данных черты по URL.
-   * @param url Идентификатор черты.
-   */
-  async function fetchFeatDetail(url: string): Promise<void> {
-    if (!url) {
-      detailFeat.value = null;
-      detailStatus.value = FetchStatus.Idle;
-
-      return;
-    }
-
-    if (featCache.has(url)) {
-      detailFeat.value = featCache.get(url) || null;
-      detailStatus.value = FetchStatus.Success;
-
-      return;
-    }
-
-    detailStatus.value = FetchStatus.Pending;
-
-    try {
-      const response = await $fetch<FeatDetailResponse>(`/api/v2/feats/${url}`);
-
-      featCache.set(url, response);
-      detailFeat.value = response;
-      detailStatus.value = FetchStatus.Success;
-    } catch {
-      detailFeat.value = null;
-      detailStatus.value = FetchStatus.Error;
-    }
-  }
-
-  const isDetailDismissed = ref(false);
-  const isRouterReady = ref(false);
-
-  watch(
+  const {
     detailUrl,
-    (url) => {
-      if (url) {
-        isDetailDismissed.value = false;
-      }
-
-      fetchFeatDetail(url);
-    },
-    { immediate: true },
-  );
-
-  const isDetailLoading = computed(
-    () => detailStatus.value === FetchStatus.Pending,
-  );
-
-  const isDetailError = computed(
-    () => detailStatus.value === FetchStatus.Error,
-  );
-
-  const detailUrlForCopy = computed(() =>
-    detailUrl.value ? `${getOrigin()}/feats/${detailUrl.value}` : undefined,
-  );
-
-  const detailEditUrl = computed(() =>
-    detailUrl.value ? `/workshop/feats/${detailUrl.value}` : undefined,
-  );
-
-  watch([isSplitActive, detailUrl], ([splitActive, urlVal]) => {
-    if (isRouterReady.value && !splitActive && urlVal) {
-      navigateTo({
-        name: 'feats-url',
-        params: { url: urlVal },
-      });
-
-      router.replace({
-        query: {
-          ...route.query,
-          detail: undefined,
-        },
-      });
-    }
-  });
-
-  /**
-   * Автоматический выбор первой черты в списке.
-   */
-  function autoSelectFirstFeat() {
-    if (!isSplitActive.value || isDetailDismissed.value) {
-      return;
-    }
-
-    const firstFeat = feats.value?.[0];
-
-    if (firstFeat && !route.query.detail) {
-      router.replace({
-        query: {
-          ...route.query,
-          detail: firstFeat.url,
-        },
-      });
-    }
-  }
-
-  onMounted(async () => {
-    await router.isReady();
-    isRouterReady.value = true;
-
-    if (!isSplitActive.value && detailUrl.value) {
-      navigateTo({
-        name: 'feats-url',
-        params: { url: detailUrl.value },
-      });
-
-      router.replace({
-        query: {
-          ...route.query,
-          detail: undefined,
-        },
-      });
-
-      return;
-    }
-
-    autoSelectFirstFeat();
-  });
-
-  watch([feats, isSplitActive], () => {
-    if (isRouterReady.value) {
-      autoSelectFirstFeat();
-    }
-  });
-
-  /**
-   * Закрытие детальной панели.
-   */
-  function handleCloseDetail() {
-    isDetailDismissed.value = true;
-
-    router.push({
-      query: {
-        ...route.query,
-        detail: undefined,
-      },
-    });
-  }
-
-  useHead(() => {
-    if (isSplitActive.value && detailUrl.value) {
-      return {
-        link: [
-          {
-            rel: 'canonical',
-            href: `${getOrigin()}/feats/${detailUrl.value}`,
-          },
-        ],
-      };
-    }
-
-    return {};
+    detailData: detailFeat,
+    isDetailLoading,
+    isDetailError,
+    isDetailDismissed,
+    detailUrlForCopy,
+    detailEditUrl,
+    handleCloseDetail,
+  } = useSectionDetail<FeatDetailResponse>({
+    sectionPath: '/feats',
+    apiBasePath: '/api/v2/feats',
+    items: feats,
   });
 
   const listResetKey = computed(() =>

--- a/app/pages/glossary/index.vue
+++ b/app/pages/glossary/index.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
-  import type { FetchStatusValue } from '~/shared/consts';
   import type {
     GlossaryDetailResponse,
     GlossaryLinkResponse,
   } from '~glossary/model';
 
-  import { FetchStatus } from '~/shared/consts';
   import { GlossaryBody } from '~glossary/body';
   import { GlossaryLink } from '~glossary/link';
   import { FilterControls, useFilter } from '~infrastructure/filter';
@@ -18,11 +16,6 @@
     title: 'Глоссарий [Glossary]',
     description: 'Глоссарий из D&D 5 (редакция 2024 года).',
   });
-
-  const { isSplitActive } = useLayoutWidth();
-
-  const route = useRoute();
-  const router = useRouter();
 
   const {
     filter,
@@ -54,175 +47,19 @@
     },
   );
 
-  const glossaryCache = createLruCache<string, GlossaryDetailResponse>(50);
-
-  const detailUrl = computed(() => {
-    const detail = route.query.detail;
-
-    return typeof detail === 'string' && detail ? detail : '';
-  });
-
-  const detailGlossary = ref<GlossaryDetailResponse | null>(null);
-  const detailStatus = ref<FetchStatusValue>(FetchStatus.Idle);
-
-  /**
-   * Загрузка детальных данных записи глоссария по URL.
-   * @param url Идентификатор записи глоссария.
-   */
-  async function fetchGlossaryDetail(url: string): Promise<void> {
-    if (!url) {
-      detailGlossary.value = null;
-      detailStatus.value = FetchStatus.Idle;
-
-      return;
-    }
-
-    if (glossaryCache.has(url)) {
-      detailGlossary.value = glossaryCache.get(url) || null;
-      detailStatus.value = FetchStatus.Success;
-
-      return;
-    }
-
-    detailStatus.value = FetchStatus.Pending;
-
-    try {
-      const response = await $fetch<GlossaryDetailResponse>(
-        `/api/v2/glossary/${url}`,
-      );
-
-      glossaryCache.set(url, response);
-      detailGlossary.value = response;
-      detailStatus.value = FetchStatus.Success;
-    } catch {
-      detailGlossary.value = null;
-      detailStatus.value = FetchStatus.Error;
-    }
-  }
-
-  const isDetailDismissed = ref(false);
-  const isRouterReady = ref(false);
-
-  watch(
+  const {
     detailUrl,
-    (url) => {
-      if (url) {
-        isDetailDismissed.value = false;
-      }
-
-      fetchGlossaryDetail(url);
-    },
-    { immediate: true },
-  );
-
-  const isDetailLoading = computed(
-    () => detailStatus.value === FetchStatus.Pending,
-  );
-
-  const isDetailError = computed(
-    () => detailStatus.value === FetchStatus.Error,
-  );
-
-  const detailUrlForCopy = computed(() =>
-    detailUrl.value ? `${getOrigin()}/glossary/${detailUrl.value}` : undefined,
-  );
-
-  const detailEditUrl = computed(() =>
-    detailUrl.value ? `/workshop/glossary/${detailUrl.value}` : undefined,
-  );
-
-  watch([isSplitActive, detailUrl], ([splitActive, urlVal]) => {
-    if (isRouterReady.value && !splitActive && urlVal) {
-      navigateTo({
-        name: 'glossary-url',
-        params: { url: urlVal },
-      });
-
-      router.replace({
-        query: {
-          ...route.query,
-          detail: undefined,
-        },
-      });
-    }
-  });
-
-  /**
-   * Автоматический выбор первой записи глоссария в списке.
-   */
-  function autoSelectFirstGlossaryItem() {
-    if (!isSplitActive.value || isDetailDismissed.value) {
-      return;
-    }
-
-    const firstGlossaryItem = glossaryItems.value?.[0];
-
-    if (firstGlossaryItem && !route.query.detail) {
-      router.replace({
-        query: {
-          ...route.query,
-          detail: firstGlossaryItem.url,
-        },
-      });
-    }
-  }
-
-  onMounted(async () => {
-    await router.isReady();
-    isRouterReady.value = true;
-
-    if (!isSplitActive.value && detailUrl.value) {
-      navigateTo({
-        name: 'glossary-url',
-        params: { url: detailUrl.value },
-      });
-
-      router.replace({
-        query: {
-          ...route.query,
-          detail: undefined,
-        },
-      });
-
-      return;
-    }
-
-    autoSelectFirstGlossaryItem();
-  });
-
-  watch([glossaryItems, isSplitActive], () => {
-    if (isRouterReady.value) {
-      autoSelectFirstGlossaryItem();
-    }
-  });
-
-  /**
-   * Закрытие детальной панели.
-   */
-  function handleCloseDetail() {
-    isDetailDismissed.value = true;
-
-    router.push({
-      query: {
-        ...route.query,
-        detail: undefined,
-      },
-    });
-  }
-
-  useHead(() => {
-    if (isSplitActive.value && detailUrl.value) {
-      return {
-        link: [
-          {
-            rel: 'canonical',
-            href: `${getOrigin()}/glossary/${detailUrl.value}`,
-          },
-        ],
-      };
-    }
-
-    return {};
+    detailData: detailGlossary,
+    isDetailLoading,
+    isDetailError,
+    isDetailDismissed,
+    detailUrlForCopy,
+    detailEditUrl,
+    handleCloseDetail,
+  } = useSectionDetail<GlossaryDetailResponse>({
+    sectionPath: '/glossary',
+    apiBasePath: '/api/v2/glossary',
+    items: glossaryItems,
   });
 
   const listResetKey = computed(() =>

--- a/app/pages/items/index.vue
+++ b/app/pages/items/index.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
-  import type { FetchStatusValue } from '~/shared/consts';
   import type { ItemDetailResponse, ItemLinkResponse } from '~items/model';
 
-  import { FetchStatus } from '~/shared/consts';
   import { FilterControls, useFilter } from '~infrastructure/filter';
   import { ItemBody } from '~items/body';
   import { ItemLink } from '~items/link';
@@ -15,11 +13,6 @@
     title: 'Предметы [Items]',
     description: 'Предметы из D&D 5 (редакция 2024 года).',
   });
-
-  const { isSplitActive } = useLayoutWidth();
-
-  const route = useRoute();
-  const router = useRouter();
 
   const {
     filter,
@@ -51,173 +44,19 @@
     },
   );
 
-  const itemCache = createLruCache<string, ItemDetailResponse>(50);
-
-  const detailUrl = computed(() => {
-    const detail = route.query.detail;
-
-    return typeof detail === 'string' && detail ? detail : '';
-  });
-
-  const detailItem = ref<ItemDetailResponse | null>(null);
-  const detailStatus = ref<FetchStatusValue>(FetchStatus.Idle);
-
-  /**
-   * Загрузка детальных данных предмета по URL.
-   * @param url Идентификатор предмета.
-   */
-  async function fetchItemDetail(url: string): Promise<void> {
-    if (!url) {
-      detailItem.value = null;
-      detailStatus.value = FetchStatus.Idle;
-
-      return;
-    }
-
-    if (itemCache.has(url)) {
-      detailItem.value = itemCache.get(url) || null;
-      detailStatus.value = FetchStatus.Success;
-
-      return;
-    }
-
-    detailStatus.value = FetchStatus.Pending;
-
-    try {
-      const response = await $fetch<ItemDetailResponse>(`/api/v2/item/${url}`);
-
-      itemCache.set(url, response);
-      detailItem.value = response;
-      detailStatus.value = FetchStatus.Success;
-    } catch {
-      detailItem.value = null;
-      detailStatus.value = FetchStatus.Error;
-    }
-  }
-
-  const isDetailDismissed = ref(false);
-  const isRouterReady = ref(false);
-
-  watch(
+  const {
     detailUrl,
-    (url) => {
-      if (url) {
-        isDetailDismissed.value = false;
-      }
-
-      fetchItemDetail(url);
-    },
-    { immediate: true },
-  );
-
-  const isDetailLoading = computed(
-    () => detailStatus.value === FetchStatus.Pending,
-  );
-
-  const isDetailError = computed(
-    () => detailStatus.value === FetchStatus.Error,
-  );
-
-  const detailUrlForCopy = computed(() =>
-    detailUrl.value ? `${getOrigin()}/items/${detailUrl.value}` : undefined,
-  );
-
-  const detailEditUrl = computed(() =>
-    detailUrl.value ? `/workshop/items/${detailUrl.value}` : undefined,
-  );
-
-  watch([isSplitActive, detailUrl], ([splitActive, urlVal]) => {
-    if (isRouterReady.value && !splitActive && urlVal) {
-      navigateTo({
-        name: 'items-url',
-        params: { url: urlVal },
-      });
-
-      router.replace({
-        query: {
-          ...route.query,
-          detail: undefined,
-        },
-      });
-    }
-  });
-
-  /**
-   * Автоматический выбор первого предмета в списке.
-   */
-  function autoSelectFirstItem() {
-    if (!isSplitActive.value || isDetailDismissed.value) {
-      return;
-    }
-
-    const firstItem = items.value?.[0];
-
-    if (firstItem && !route.query.detail) {
-      router.replace({
-        query: {
-          ...route.query,
-          detail: firstItem.url,
-        },
-      });
-    }
-  }
-
-  onMounted(async () => {
-    await router.isReady();
-    isRouterReady.value = true;
-
-    if (!isSplitActive.value && detailUrl.value) {
-      navigateTo({
-        name: 'items-url',
-        params: { url: detailUrl.value },
-      });
-
-      router.replace({
-        query: {
-          ...route.query,
-          detail: undefined,
-        },
-      });
-
-      return;
-    }
-
-    autoSelectFirstItem();
-  });
-
-  watch([items, isSplitActive], () => {
-    if (isRouterReady.value) {
-      autoSelectFirstItem();
-    }
-  });
-
-  /**
-   * Закрытие детальной панели.
-   */
-  function handleCloseDetail() {
-    isDetailDismissed.value = true;
-
-    router.push({
-      query: {
-        ...route.query,
-        detail: undefined,
-      },
-    });
-  }
-
-  useHead(() => {
-    if (isSplitActive.value && detailUrl.value) {
-      return {
-        link: [
-          {
-            rel: 'canonical',
-            href: `${getOrigin()}/items/${detailUrl.value}`,
-          },
-        ],
-      };
-    }
-
-    return {};
+    detailData: detailItem,
+    isDetailLoading,
+    isDetailError,
+    isDetailDismissed,
+    detailUrlForCopy,
+    detailEditUrl,
+    handleCloseDetail,
+  } = useSectionDetail<ItemDetailResponse>({
+    sectionPath: '/items',
+    apiBasePath: '/api/v2/item',
+    items,
   });
 
   const listResetKey = computed(() =>

--- a/app/pages/magic-items/index.vue
+++ b/app/pages/magic-items/index.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
-  import type { FetchStatusValue } from '~/shared/consts';
   import type {
     MagicItemDetailResponse,
     MagicItemLinkResponse,
   } from '~magic-items/model';
 
-  import { FetchStatus } from '~/shared/consts';
   import { FilterControls, useFilter } from '~infrastructure/filter';
   import { MagicItemBody } from '~magic-items/body';
   import { useMagicItemRarityGroupOrder } from '~magic-items/composable';
@@ -20,11 +18,6 @@
     title: 'Магические предметы [Magic Items]',
     description: 'Магические предметы из D&D 5 (редакция 2024 года).',
   });
-
-  const { isSplitActive } = useLayoutWidth();
-
-  const route = useRoute();
-  const router = useRouter();
 
   const {
     filter,
@@ -59,177 +52,19 @@
     },
   );
 
-  const magicItemCache = createLruCache<string, MagicItemDetailResponse>(50);
-
-  const detailUrl = computed(() => {
-    const detail = route.query.detail;
-
-    return typeof detail === 'string' && detail ? detail : '';
-  });
-
-  const detailMagicItem = ref<MagicItemDetailResponse | null>(null);
-  const detailStatus = ref<FetchStatusValue>(FetchStatus.Idle);
-
-  /**
-   * Загрузка детальных данных магического предмета по URL.
-   * @param url Идентификатор магического предмета.
-   */
-  async function fetchMagicItemDetail(url: string): Promise<void> {
-    if (!url) {
-      detailMagicItem.value = null;
-      detailStatus.value = FetchStatus.Idle;
-
-      return;
-    }
-
-    if (magicItemCache.has(url)) {
-      detailMagicItem.value = magicItemCache.get(url) || null;
-      detailStatus.value = FetchStatus.Success;
-
-      return;
-    }
-
-    detailStatus.value = FetchStatus.Pending;
-
-    try {
-      const response = await $fetch<MagicItemDetailResponse>(
-        `/api/v2/magic-items/${url}`,
-      );
-
-      magicItemCache.set(url, response);
-      detailMagicItem.value = response;
-      detailStatus.value = FetchStatus.Success;
-    } catch {
-      detailMagicItem.value = null;
-      detailStatus.value = FetchStatus.Error;
-    }
-  }
-
-  const isDetailDismissed = ref(false);
-  const isRouterReady = ref(false);
-
-  watch(
+  const {
     detailUrl,
-    (url) => {
-      if (url) {
-        isDetailDismissed.value = false;
-      }
-
-      fetchMagicItemDetail(url);
-    },
-    { immediate: true },
-  );
-
-  const isDetailLoading = computed(
-    () => detailStatus.value === FetchStatus.Pending,
-  );
-
-  const isDetailError = computed(
-    () => detailStatus.value === FetchStatus.Error,
-  );
-
-  const detailUrlForCopy = computed(() =>
-    detailUrl.value
-      ? `${getOrigin()}/magic-items/${detailUrl.value}`
-      : undefined,
-  );
-
-  const detailEditUrl = computed(() =>
-    detailUrl.value ? `/workshop/magic-items/${detailUrl.value}` : undefined,
-  );
-
-  watch([isSplitActive, detailUrl], ([splitActive, urlVal]) => {
-    if (isRouterReady.value && !splitActive && urlVal) {
-      navigateTo({
-        name: 'magic-items-url',
-        params: { url: urlVal },
-      });
-
-      router.replace({
-        query: {
-          ...route.query,
-          detail: undefined,
-        },
-      });
-    }
-  });
-
-  /**
-   * Автоматический выбор первого магического предмета в списке.
-   */
-  function autoSelectFirstMagicItem() {
-    if (!isSplitActive.value || isDetailDismissed.value) {
-      return;
-    }
-
-    const firstMagicItem = magicItems.value?.[0];
-
-    if (firstMagicItem && !route.query.detail) {
-      router.replace({
-        query: {
-          ...route.query,
-          detail: firstMagicItem.url,
-        },
-      });
-    }
-  }
-
-  onMounted(async () => {
-    await router.isReady();
-    isRouterReady.value = true;
-
-    if (!isSplitActive.value && detailUrl.value) {
-      navigateTo({
-        name: 'magic-items-url',
-        params: { url: detailUrl.value },
-      });
-
-      router.replace({
-        query: {
-          ...route.query,
-          detail: undefined,
-        },
-      });
-
-      return;
-    }
-
-    autoSelectFirstMagicItem();
-  });
-
-  watch([magicItems, isSplitActive], () => {
-    if (isRouterReady.value) {
-      autoSelectFirstMagicItem();
-    }
-  });
-
-  /**
-   * Закрытие детальной панели.
-   */
-  function handleCloseDetail() {
-    isDetailDismissed.value = true;
-
-    router.push({
-      query: {
-        ...route.query,
-        detail: undefined,
-      },
-    });
-  }
-
-  useHead(() => {
-    if (isSplitActive.value && detailUrl.value) {
-      return {
-        link: [
-          {
-            rel: 'canonical',
-            href: `${getOrigin()}/magic-items/${detailUrl.value}`,
-          },
-        ],
-      };
-    }
-
-    return {};
+    detailData: detailMagicItem,
+    isDetailLoading,
+    isDetailError,
+    isDetailDismissed,
+    detailUrlForCopy,
+    detailEditUrl,
+    handleCloseDetail,
+  } = useSectionDetail<MagicItemDetailResponse>({
+    sectionPath: '/magic-items',
+    apiBasePath: '/api/v2/magic-items',
+    items: magicItems,
   });
 
   const isLoading = computed(() => {


### PR DESCRIPTION
…авочника

Разделы glossary, feats, backgrounds, magic-items и items использовали собственную inline-копию логики детальной панели вместо общего composable useSectionDetail (в отличие от spells, bestiary, species, classes, sources). Из-за этого ссылка вида /glossary?detail=<url>, расшаренная из широкого режима, не открывалась корректно у пользователя в стандартном режиме.

Причины:
- отсутствовал серверный 302-редирект с ?detail= на /<раздел>/<url>;
- в onMounted и watch шли подряд navigateTo(детальная страница) и router.replace({ detail: undefined }) — второй вызов синхронно отменял первый, и вместо детальной страницы открывался голый список.

Что сделано:
- все пять страниц-списков переведены на composable useSectionDetail, как и остальные разделы; это добавляет серверный 302-редирект и убирает баг двойной навигации;
- удалено ~877 строк продублированной логики (кэш, fetch, авто-выбор первого элемента, обработчики, canonical) и неиспользуемые импорты;
- для items учтён singular API: sectionPath '/items', apiBasePath '/api/v2/item'.

Обратное направление (/<раздел>/<url> -> ?detail= в широком режиме) уже работало через useSectionDetailRedirect и не затрагивалось.

Проверено на dev-сервере: запрос ?detail= без cookie ширины отдаёт 302 на /<раздел>/<url>, с cookie ttg-layout-width=wide остаётся 200. Карточки списка по-прежнему рендерятся как <a href="/<раздел>/<url>">, поэтому индексация поисковыми роботами не меняется.