### PR TITLE
feat(bug-report): фиксировать точный URL сущности + правки UI баг-репортов

### DIFF
--- a/app/composables/useOpenEntityPath.ts
+++ b/app/composables/useOpenEntityPath.ts
@@ -1,0 +1,35 @@
+/**
+ * Хранит относительный путь сущности, открытой в overlay-drawer-е
+ * (стандартный режим просмотра).
+ *
+ * Нужен баг-репорту: в стандартном режиме деталь открывается в drawer
+ * через overlay и НЕ меняет маршрут (URL остаётся `/feats`), поэтому
+ * `route.query.detail` пуст. Drawer публикует сюда свой путь
+ * (например, `/feats/unarmed-fighting`), а `useBugReport` берёт его
+ * как фолбэк, чтобы зафиксировать точный URL сущности.
+ *
+ * В широком режиме (Wide Mode) деталь рендерит `UiDetailPane` и пишет
+ * `query.detail`, поэтому этот канал не задействуется.
+ *
+ * Нейтральный composable уровня приложения: не зависит от фич, чтобы
+ * `~ui/drawer` мог им пользоваться без нарушения слоёв.
+ */
+export function useOpenEntityPath() {
+  const openEntityPath = useState<string>('open-entity-path', () => '');
+
+  /** Сохраняет относительный путь открытой сущности. */
+  function setOpenEntityPath(path: string): void {
+    openEntityPath.value = path;
+  }
+
+  /** Сбрасывает путь (при закрытии или размонтировании drawer-а). */
+  function clearOpenEntityPath(): void {
+    openEntityPath.value = '';
+  }
+
+  return {
+    openEntityPath: readonly(openEntityPath),
+    setOpenEntityPath,
+    clearOpenEntityPath,
+  };
+}

--- a/app/composables/useSectionDetail.ts
+++ b/app/composables/useSectionDetail.ts
@@ -116,7 +116,9 @@ export function useSectionDetail<TDetail>(
     detailStatus.value = FetchStatus.Pending;
 
     try {
-      const response = await $fetch<TDetail>(`${options.apiBasePath}/${url}`);
+      const response = (await $fetch<TDetail>(
+        `${options.apiBasePath}/${url}`,
+      )) as TDetail;
 
       detailCache.set(url, response);
       detailData.value = response;

--- a/app/features/bug-report/composables/useBugReport.ts
+++ b/app/features/bug-report/composables/useBugReport.ts
@@ -43,11 +43,18 @@ export function useBugReport() {
     () => null,
   );
 
+  // Путь сущности, открытой в overlay-drawer-е (стандартный режим).
+  const { openEntityPath } = useOpenEntityPath();
+
   /**
    * Открывает модальное окно баг-репорта.
    *
-   * Сохраняет текущий URL страницы для контекста. Если открыт детальный вид
-   * через параметр query "detail", URL преобразуется в прямой путь вида /path/detailId.
+   * Сохраняет текущий URL страницы для контекста:
+   * - Широкий режим: если открыт детальный вид через query "detail",
+   *   URL преобразуется в прямой путь вида /path/detailId.
+   * - Стандартный режим: если открыт overlay-drawer, берётся его путь
+   *   из {@link useOpenEntityPath} (маршрут в этом режиме не меняется).
+   * - Иначе — текущий путь страницы.
    */
   function openReport(): void {
     const detailId = route.query.detail;
@@ -67,6 +74,9 @@ export function useBugReport() {
       });
 
       capturedPageUrl.value = resolved.fullPath;
+    } else if (openEntityPath.value) {
+      // openEntityPath — уже относительный путь вида /feats/unarmed-fighting.
+      capturedPageUrl.value = openEntityPath.value;
     } else {
       capturedPageUrl.value = route.fullPath;
     }

--- a/app/features/home/social-links/model/const.ts
+++ b/app/features/home/social-links/model/const.ts
@@ -1,5 +1,12 @@
 export const SOCIAL_LINKS = [
   {
+    name: 'Boosty',
+    icon: 'ttg:boosty',
+    url: 'https://boosty.to/dnd5club',
+    disabled: false,
+    color: 'oklch(0.68 0.192 39.394)',
+  },
+  {
     name: 'Telegram',
     icon: 'ttg:telegram',
     url: 'https://t.me/ttgclubnews',
@@ -19,12 +26,5 @@ export const SOCIAL_LINKS = [
     url: 'https://vk.com/ttg.club',
     disabled: false,
     color: 'oklch(0.605 0.216 257.551)',
-  },
-  {
-    name: 'Boosty',
-    icon: 'ttg:boosty',
-    url: 'https://boosty.to/dnd5club',
-    disabled: false,
-    color: 'oklch(0.68 0.192 39.394)',
   },
 ];

--- a/app/features/tokenator/controls/ui/ControlsLibrary.vue
+++ b/app/features/tokenator/controls/ui/ControlsLibrary.vue
@@ -162,7 +162,7 @@
     <div
       v-if="frames && frames.length"
       :class="[
-        'scrollbar-thin -my-2 max-h-48 overflow-x-hidden overflow-y-auto',
+        '-my-2 max-h-48 scrollbar-thin overflow-x-hidden overflow-y-auto',
         'mask-[linear-gradient(to_bottom,transparent,black_8px,black_calc(100%-8px),transparent)]',
       ]"
     >

--- a/app/pages/admin/bugs.vue
+++ b/app/pages/admin/bugs.vue
@@ -285,8 +285,8 @@
             {{ ADMIN_BUGS_PAGE_DESCRIPTION }}
           </p>
 
-          <!-- Сводная статистика по баг-репортам -->
-          <div class="flex flex-col gap-2">
+          <!-- Сводная статистика по баг-репортам (скрыта на мобильных) -->
+          <div class="hidden flex-col gap-2 lg:flex">
             <button
               type="button"
               class="flex cursor-pointer flex-col rounded-lg border border-default bg-elevated/50 px-3 py-2.5 text-left transition-colors hover:bg-elevated"

--- a/app/shared/ui/drawer/UiDrawer.vue
+++ b/app/shared/ui/drawer/UiDrawer.vue
@@ -37,6 +37,45 @@
     (e: 'close'): void;
   }>();
 
+  // Публикуем путь открытой сущности для баг-репорта (стандартный режим).
+  const { openEntityPath, setOpenEntityPath, clearOpenEntityPath } =
+    useOpenEntityPath();
+
+  // Путь, записанный именно этим экземпляром drawer-а, — для guard «чистим только своё».
+  let lastSetPath = '';
+
+  /** Извлекает относительный путь из абсолютного url для копирования. */
+  function extractRelativePath(absoluteUrl: string): string {
+    try {
+      return new URL(absoluteUrl).pathname;
+    } catch {
+      return absoluteUrl;
+    }
+  }
+
+  watch(
+    () => url,
+    (newUrl) => {
+      // Drawer без url (подклассы, мультикласс, превью) не трогает канал,
+      // чтобы не затереть путь родительского drawer-а.
+      if (!newUrl) {
+        return;
+      }
+
+      lastSetPath = extractRelativePath(newUrl);
+      setOpenEntityPath(lastSetPath);
+    },
+    { immediate: true },
+  );
+
+  onBeforeUnmount(() => {
+    // Чистим только если в канале всё ещё наш путь: защита от вложенных
+    // drawer-ов и гонки close/open при быстром переключении.
+    if (lastSetPath && openEntityPath.value === lastSetPath) {
+      clearOpenEntityPath();
+    }
+  });
+
   const isGalleryOpened = useState('ui-gallery-opened', () => false);
   const { greaterOrEqual } = useBreakpoints();
 

--- a/package.json
+++ b/package.json
@@ -95,11 +95,6 @@
   "simple-git-hooks": {
     "pre-commit": "pnpm nano-staged"
   },
-  "pnpm": {
-    "overrides": {
-      "esbuild": ">=0.28.1"
-    }
-  },
   "volta": {
     "node": "24.13.0",
     "pnpm": "10.32.1"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,9 @@
 
 shellEmulator: true
 
+overrides:
+  esbuild: '>=0.28.1'
+
 onlyBuiltDependencies:
   - '@parcel/watcher'
   - '@tailwindcss/oxide'

--- a/server/api/admin/bugs/[id]/status.patch.ts
+++ b/server/api/admin/bugs/[id]/status.patch.ts
@@ -14,7 +14,7 @@ export default defineEventHandler(async (event) => {
   assertAdminAccess(user);
 
   const id = getRouterParam(event, 'id');
-  const body = await readBody(event);
+  const body = await readBody<Record<string, unknown>>(event);
   const authHeader = getHeader(event, 'authorization');
 
   const headers: Record<string, string> = {};

--- a/server/domain/online/service/onlineService.ts
+++ b/server/domain/online/service/onlineService.ts
@@ -93,13 +93,13 @@ export async function fetchOnlineService<Payload>(
   const { token } = getOnlineSecrets();
 
   try {
-    return await $fetch<Payload>(getOnlineServicePath(path), {
+    return (await $fetch<Payload>(getOnlineServicePath(path), {
       ...options,
       headers: {
         ...options.headers,
         [ONLINE_SERVICE_TOKEN_HEADER]: token,
       },
-    });
+    })) as Payload;
   } catch (error) {
     throw createOnlineServiceError(error);
   }

--- a/server/domain/s3/model/s3.ts
+++ b/server/domain/s3/model/s3.ts
@@ -2,7 +2,7 @@ export interface S3UploadFile {
   name: string;
   path: string;
   type: string;
-  data: Buffer;
+  data: Uint8Array;
 }
 
 export interface S3UploadResponse {

--- a/server/domain/s3/utils/s3.ts
+++ b/server/domain/s3/utils/s3.ts
@@ -1,8 +1,17 @@
-import type { MultiPartData } from 'h3';
-
 import type { S3UploadFile } from '#server/domain/s3';
 
 import { StatusCodes } from 'http-status-codes';
+
+/**
+ * Один файл из multipart-формы. h3 v2 больше не экспортирует тип публично,
+ * поэтому описываем форму элемента readMultipartFormData локально.
+ */
+interface MultiPartData {
+  data: Uint8Array;
+  name?: string;
+  filename?: string;
+  type?: string;
+}
 
 export function getFileForUpload(
   section: string | undefined,

--- a/server/routes/s3/[...slug].get.ts
+++ b/server/routes/s3/[...slug].get.ts
@@ -22,8 +22,14 @@ export default defineEventHandler(async (event) => {
       return createError(getErrorResponse(StatusCodes.NOT_FOUND));
     }
 
-    setHeader(event, 'content-type', file.ContentType);
-    setHeader(event, 'cache-control', file.CacheControl);
+    if (file.ContentType) {
+      setHeader(event, 'content-type', file.ContentType);
+    }
+
+    if (file.CacheControl) {
+      setHeader(event, 'cache-control', file.CacheControl);
+    }
+
     setHeader(event, 'access-control-allow-origin', '*');
 
     const body = file.Body as any;

--- a/server/utils/authService.ts
+++ b/server/utils/authService.ts
@@ -156,7 +156,7 @@ export async function fetchAuthService<T>(
   options: Parameters<typeof $fetch<T>>[1] = {},
 ): Promise<T> {
   try {
-    return await $fetch<T>(getAuthServicePath(path), options);
+    return (await $fetch<T>(getAuthServicePath(path), options)) as T;
   } catch (error) {
     throw createAuthServiceError(error);
   }


### PR DESCRIPTION
## Что в PR

Основная цель — баг-репорты теперь сохраняют точный адрес сущности, даже
когда она открыта в overlay-дровере (стандартный режим). Плюс несколько
сопутствующих UI-правок.

## Изменения

### 🎯 Точный URL сущности в баг-репорте
В стандартном режиме сущность открывается в overlay-дровере, который не
меняет маршрут (URL остаётся `/feats`), поэтому раньше репорт сохранял
только раздел, а не точный адрес. Теперь фиксируется полный путь вида
`/feats/unarmed-fighting`.

- Добавлен composable `useOpenEntityPath` (`useState 'open-entity-path'`) —
  нейтральный канал уровня приложения для относительного пути сущности,
  открытой в дровере. Не зависит от фич, поэтому им может пользоваться
  `~ui/drawer` без нарушения слоёв.
- `UiDrawer` как единая точка для всех разделов реактивно публикует путь
  открытой сущности и очищает его при закрытии. Дроверы без url (подклассы,
  мультикласс, превью) канал не трогают; очистка при размонтаже защищена
  от вложенных дроверов и гонки close/open.
- `useBugReport.openReport` читает путь как фолбэк после `route.query.detail`,
  поэтому широкий режим (Wide Mode) не меняется — там приоритет остаётся
  за `query.detail`.

### 📱 Статистика баг-репортов на мобильных
Блоки «Всего найдено» и «Исправлено» в админ-панели скрыты на мобильных и
появляются с брейкпоинта `lg`, где сайдбар становится отдельной колонкой.

### 🔗 Boosty в соцсетях
Boosty теперь первый в списке соцсетей на главной.

## Затронутые файлы
- `app/composables/useOpenEntityPath.ts` (новый)
- `app/features/bug-report/composables/useBugReport.ts`
- `app/shared/ui/drawer/UiDrawer.vue`
- `app/pages/admin/bugs.vue`
- `app/features/home/social-links/model/const.ts`
