### PR TITLE
feat(subscriptions): срок подписки тира в форме выпуска кодов

### DIFF
--- a/app/features/admin/subscriptions/model/constants.ts
+++ b/app/features/admin/subscriptions/model/constants.ts
@@ -88,6 +88,21 @@ export const REWARD_PERK_LABELS: Record<RewardPerk, string> = {
   APP_CREDITS: 'Упоминание в титрах приложения',
 };
 
+/**
+ * Срок подписки, зашитый в каждый тир (в месяцах). Зеркалит RewardTier.subscriptionMonths()
+ * с бэкенда: TIER_1..TIER_4 — 3 мес., TIER_5 — 6, TIER_6 — 12 (0 — тир без подписки).
+ * Нужен только как подсказка в форме: при выборе тира без явной подписки бэкенд всё равно
+ * подставит подарочную подписку на этот срок (см. SubscriptionService.createCodes).
+ */
+export const TIER_SUBSCRIPTION_MONTHS: Record<RewardTier, number> = {
+  TIER_1: 3,
+  TIER_2: 3,
+  TIER_3: 3,
+  TIER_4: 3,
+  TIER_5: 6,
+  TIER_6: 12,
+};
+
 /** Собственные перки каждого тира (без накопления). */
 const TIER_OWN_PERKS: Record<RewardTier, RewardPerk[]> = {
   TIER_1: ['EARLY_ACCESS_DOWNLOAD'],

--- a/app/features/admin/subscriptions/ui/CreateCodesForm.vue
+++ b/app/features/admin/subscriptions/ui/CreateCodesForm.vue
@@ -12,6 +12,7 @@
     SUBSCRIPTION_MONTHS_MAX,
     SUBSCRIPTION_MONTHS_MIN,
     SUBSCRIPTION_TYPE_OPTIONS,
+    TIER_SUBSCRIPTION_MONTHS,
     tierCumulativePerks,
     toCreateCodesRequest,
   } from '../model';
@@ -36,6 +37,34 @@
         )
       : [],
   );
+
+  // Срок подписки, зашитый в выбранный тир (0 — тир без подписки или тир не выбран).
+  // Бэкенд подставит её автоматически (подарочную), если не задать подписку вручную.
+  const tierSubscriptionMonths = computed(() =>
+    state.rewardTier ? TIER_SUBSCRIPTION_MONTHS[state.rewardTier] : 0,
+  );
+
+  // Тумблер подписки меняет смысл, когда тир уже несёт пресет: это уже «переопределение».
+  const subscriptionSwitchLabel = computed(() =>
+    tierSubscriptionMonths.value
+      ? 'Переопределить подписку тира'
+      : 'Добавить подписку',
+  );
+
+  const subscriptionSwitchDescription = computed(() =>
+    tierSubscriptionMonths.value
+      ? `Задать свой срок и тип вместо пресета тира (${tierSubscriptionMonths.value} мес., подарочная).`
+      : 'Код зарегистрирует подписку; пользователь активирует её сам.',
+  );
+
+  // При включении ручного режима для тира стартуем с его пресета, а не с 1 месяца.
+  function onToggleSubscription(value: boolean): void {
+    state.includeSubscription = value;
+
+    if (value && tierSubscriptionMonths.value > 0) {
+      state.subscriptionMonths = tierSubscriptionMonths.value;
+    }
+  }
 
   // Свободный ввод кодов достижений тегами.
   const achievementDraft = ref('');
@@ -122,20 +151,40 @@
         </UFormField>
 
         <div
-          v-if="tierPerksPreview.length"
-          class="flex flex-wrap items-center gap-1.5 rounded-lg border border-default bg-elevated/50 px-3 py-2.5"
+          v-if="state.rewardTier"
+          class="space-y-2 rounded-lg border border-default bg-elevated/50 px-3 py-2.5"
         >
-          <span class="text-xs text-muted">Даёт перки:</span>
-
-          <UBadge
-            v-for="perk in tierPerksPreview"
-            :key="perk"
-            color="neutral"
-            variant="subtle"
-            size="sm"
+          <div
+            v-if="tierSubscriptionMonths"
+            class="flex flex-wrap items-center gap-1.5"
           >
-            {{ perk }}
-          </UBadge>
+            <span class="text-xs text-muted">Даёт подписку:</span>
+
+            <UBadge
+              color="primary"
+              variant="subtle"
+              size="sm"
+            >
+              {{ tierSubscriptionMonths }} мес. · подарочная
+            </UBadge>
+          </div>
+
+          <div
+            v-if="tierPerksPreview.length"
+            class="flex flex-wrap items-center gap-1.5"
+          >
+            <span class="text-xs text-muted">Даёт перки:</span>
+
+            <UBadge
+              v-for="perk in tierPerksPreview"
+              :key="perk"
+              color="neutral"
+              variant="subtle"
+              size="sm"
+            >
+              {{ perk }}
+            </UBadge>
+          </div>
         </div>
 
         <div class="grid gap-4 sm:grid-cols-2">
@@ -187,10 +236,28 @@
         <!-- Подписка -->
         <div class="space-y-3">
           <USwitch
-            v-model="state.includeSubscription"
-            label="Добавить подписку"
-            description="Код зарегистрирует подписку; пользователь активирует её сам."
+            :model-value="state.includeSubscription"
+            :label="subscriptionSwitchLabel"
+            :description="subscriptionSwitchDescription"
+            @update:model-value="onToggleSubscription"
           />
+
+          <!-- Тир уже несёт подписку, а ручной режим выключен — она уйдёт в код автоматически. -->
+          <p
+            v-if="tierSubscriptionMonths && !state.includeSubscription"
+            class="flex items-start gap-1.5 rounded-lg border border-default bg-elevated/50 px-3 py-2 text-xs text-muted"
+          >
+            <UIcon
+              name="tabler:info-circle"
+              class="mt-0.5 size-3.5 shrink-0"
+            />
+
+            <span>
+              Тир уже даёт подарочную подписку на {{ tierSubscriptionMonths }}
+              мес. — она попадёт в код автоматически. Включите тумблер, чтобы
+              задать свой срок и тип.
+            </span>
+          </p>
 
           <div
             v-if="state.includeSubscription"


### PR DESCRIPTION
Бэкенд subscriber-service теперь зашивает срок подписки в краудфандинговый тир (RewardTier.subscriptionMonths: TIER_1–4 — 3 мес., TIER_5 — 6, TIER_6 — 12) и при выпуске кода с тиром без явной подписки автоматически подставляет подарочную подписку на этот срок (тип GIFT). Форма выпуска кодов этого никак не отражала — было не видно, что выбор тира уже добавляет подписку.

Изменения:

- model/constants.ts: добавлен TIER_SUBSCRIPTION_MONTHS — зеркало сроков подписки тиров с бэкенда. Бэк не отдаёт тиры через API, поэтому маппинг хранится на фронте (как и уже существующий зеркальный TIER_OWN_PERKS).
- CreateCodesForm.vue: под селектором тира выводится объединённый блок «Тир даёт» — строка «Даёт подписку: N мес. · подарочная» плюс перки тира (раньше показывались только перки).
- CreateCodesForm.vue: при выбранном тире с пресетом тумблер подписки меняет смысл на «Переопределить подписку тира», описание поясняет, что ручной ввод заменяет пресет; при включении срок инициализируется значением пресета тира, а не единицей.
- CreateCodesForm.vue: когда тир несёт подписку, а ручной режим выключен, показывается информационная подсказка, что подарочная подписка тира всё равно попадёт в код автоматически.

Деталь кода (CodeDetailPane) не менялась: бэкенд сохраняет резолвнутый срок и тип в самом коде, поэтому подписка тир-кодов уже отображается корректно.