### PR TITLE
feat(subscriptions): награды по кодам (скачивание, рамка аватара) и устойчивый фоновый опрос статуса

### DIFF
--- a/app/features/infrastructure/filter/utils/index.ts
+++ b/app/features/infrastructure/filter/utils/index.ts
@@ -1,6 +1,6 @@
 export * from './buildFullQuery';
 export * from './collectGroupKeys';
-export * from './filterParser';
 export * from './filterDependencies';
+export * from './filterParser';
 export * from './getFilterKey';
 export * from './getGroupItems';

--- a/app/features/profile/activation/composables/useMyRewards.ts
+++ b/app/features/profile/activation/composables/useMyRewards.ts
@@ -13,9 +13,11 @@ import {
 export function useMyRewards() {
   const requestFetch = useRequestFetch();
 
+  // retry: 0 — фоновый опрос не должен удваиваться авто-ретраем ofetch (в т.ч. на
+  // 429), иначе при rate-limit мы сами усиливаем нагрузку. См. useSubscriptionAutoRefresh.
   const { data, status, error, refresh } = useAsyncData<UserReward[]>(
     SUBSCRIPTION_MY_REWARDS_DATA_KEY,
-    () => requestFetch(REWARDS_MY_API_PATH),
+    () => requestFetch(REWARDS_MY_API_PATH, { retry: 0 }),
     { default: () => [], server: false },
   );
 

--- a/app/features/profile/activation/composables/useMySubscriptions.ts
+++ b/app/features/profile/activation/composables/useMySubscriptions.ts
@@ -13,9 +13,11 @@ export function useMySubscriptions() {
   // server: false — приватные данные пользователя грузим на клиенте, где авторизация
   // (cookie → Bearer → subscriber) гарантированно работает. На SSR этот запрос
   // возвращался пустым, и Nuxt переиспользовал пустой payload после F5.
+  // retry: 0 — фоновый опрос не должен удваиваться авто-ретраем ofetch (в т.ч. на
+  // 429), иначе при rate-limit мы сами усиливаем нагрузку. См. useSubscriptionAutoRefresh.
   const { data, status, error, refresh } = useAsyncData<Subscription[]>(
     SUBSCRIPTION_MY_DATA_KEY,
-    () => requestFetch(SUBSCRIPTION_MY_API_PATH),
+    () => requestFetch(SUBSCRIPTION_MY_API_PATH, { retry: 0 }),
     { default: () => [], server: false },
   );
 

--- a/app/features/profile/activation/composables/useSubscriptionAutoRefresh.ts
+++ b/app/features/profile/activation/composables/useSubscriptionAutoRefresh.ts
@@ -1,50 +1,140 @@
 import {
-  SUBSCRIPTION_LIVE_DATA_KEYS,
+  useDocumentVisibility,
+  useEventListener,
+  useIntervalFn,
+} from '@vueuse/core';
+
+import {
+  SUBSCRIPTION_POLL_COOLDOWN_MS,
   SUBSCRIPTION_POLL_INTERVAL_MS,
+  SUBSCRIPTION_POLL_MAX_BACKOFF_MS,
 } from '../model';
+import { useMyRewards } from './useMyRewards';
+import { useMySubscriptions } from './useMySubscriptions';
 
 /**
  * Держит статус подписки/перки актуальными без F5: по таймеру и при возврате на
- * вкладку (focus/visibilitychange) обновляет «живые» ключи — статус подписки и перки
- * (блок статуса вверху профиля и бейдж/значок/цвет ника в сайдбаре). Обновление
- * «тихое»: данные шарятся по ключу useAsyncData и не показывают индикатор загрузки
- * на фоновом опросе (см. isInitialLoading). Список кодов фоном не опрашивается.
+ * вкладку/окно обновляет «живые» данные — статус подписки и перки (блок статуса
+ * вверху профиля и бейдж/значок/цвет ника в сайдбаре). Обновление «тихое»: данные
+ * шарятся по ключу useAsyncData и не показывают индикатор загрузки на фоновом
+ * опросе (см. isInitialLoading). Список кодов фоном не опрашивается.
+ *
+ * Защита от самоограничения по rate-limit (чтобы фронт сам себя не ронял в 429):
+ * - таймер ПАУЗИТСЯ на скрытой вкладке (Page Visibility) — оставленная в фоне
+ *   вкладка не шлёт запросы; при возврате обновляемся разово;
+ * - cooldown между любыми обновлениями — серия focus/visibility не выдаёт пачку;
+ * - single-flight — не запускаем новый опрос, пока не завершился предыдущий;
+ * - на 429 включается экспоненциальный backoff (до потолка) — пока сервер
+ *   лимитирует, опрашиваем реже; успех сбрасывает backoff;
+ * - сами запросы идут с retry: 0 (см. useMySubscriptions/useMyRewards), чтобы
+ *   ofetch не удваивал их авто-ретраем на 429.
+ *
  * Вызывать один раз на странице профиля (в сайдбаре), чтобы был один таймер на раздел.
  */
 export function useSubscriptionAutoRefresh() {
-  function refreshSubscriptionData(): Promise<void> {
-    return refreshNuxtData(SUBSCRIPTION_LIVE_DATA_KEYS);
+  const { refresh: refreshSubscriptions, error: subscriptionsError } =
+    useMySubscriptions();
+
+  const { refresh: refreshRewards, error: rewardsError } = useMyRewards();
+
+  async function refreshSubscriptionData(): Promise<void> {
+    await Promise.all([refreshSubscriptions(), refreshRewards()]);
   }
 
   if (import.meta.client) {
-    let pollTimer: ReturnType<typeof setInterval> | undefined;
+    const visibility = useDocumentVisibility();
 
-    function onFocus(): void {
-      void refreshSubscriptionData();
+    // Опрос идёт через «затвор» nextAllowedAt — он держит и cooldown, и backoff.
+    let inFlight = false;
+    let nextAllowedAt = 0;
+    let backoffMs = 0;
+
+    function isRateLimited(error: unknown): boolean {
+      const err = error as
+        | {
+            statusCode?: number;
+            status?: number;
+            response?: { status?: number };
+          }
+        | null
+        | undefined;
+
+      return (
+        err?.statusCode === 429
+        || err?.status === 429
+        || err?.response?.status === 429
+      );
     }
 
-    function onVisibilityChange(): void {
-      if (document.visibilityState === 'visible') {
-        void refreshSubscriptionData();
+    async function runRefresh(): Promise<void> {
+      // Скрытую вкладку не опрашиваем ни по одному триггеру (таймер/focus/visibility):
+      // как в online-heartbeat, проверку видимости держим на всех путях обновления —
+      // focus может прийти, пока вкладка ещё hidden (гонка с visibilitychange).
+      if (
+        visibility.value === 'hidden'
+        || inFlight
+        || Date.now() < nextAllowedAt
+      ) {
+        return;
+      }
+
+      inFlight = true;
+
+      try {
+        await refreshSubscriptionData();
+      } catch {
+        // refresh() обычно не бросает (ошибку кладёт в error ref) — глотаем,
+        // фактический статус читаем из error ref ниже.
+      } finally {
+        inFlight = false;
+
+        // Статус берём из error ref (а не из ветки try/catch): backoff сработает
+        // и когда refresh проглотил ошибку в ref, и когда отклонил промис.
+        if (
+          isRateLimited(subscriptionsError.value)
+          || isRateLimited(rewardsError.value)
+        ) {
+          // Экспоненциальный backoff: пока держится лимит — стучимся всё реже.
+          backoffMs = Math.min(
+            backoffMs ? backoffMs * 2 : SUBSCRIPTION_POLL_INTERVAL_MS,
+            SUBSCRIPTION_POLL_MAX_BACKOFF_MS,
+          );
+
+          nextAllowedAt = Date.now() + backoffMs;
+        } else {
+          backoffMs = 0;
+          nextAllowedAt = Date.now() + SUBSCRIPTION_POLL_COOLDOWN_MS;
+        }
       }
     }
 
-    onMounted(() => {
-      pollTimer = setInterval(() => {
-        void refreshSubscriptionData();
-      }, SUBSCRIPTION_POLL_INTERVAL_MS);
+    const { pause, resume } = useIntervalFn(
+      () => {
+        void runRefresh();
+      },
+      SUBSCRIPTION_POLL_INTERVAL_MS,
+      { immediate: false },
+    );
 
-      document.addEventListener('visibilitychange', onVisibilityChange);
-      window.addEventListener('focus', onFocus);
+    // Пауза на скрытой вкладке; при возврате — рестарт таймера и разовое обновление.
+    watch(visibility, (state) => {
+      if (state === 'visible') {
+        resume();
+        void runRefresh();
+      } else {
+        pause();
+      }
     });
 
-    onBeforeUnmount(() => {
-      if (pollTimer) {
-        clearInterval(pollTimer);
-      }
+    // Возврат фокуса в окно (когда вкладка уже была видимой) — тоже повод обновиться.
+    useEventListener(window, 'focus', () => {
+      void runRefresh();
+    });
 
-      document.removeEventListener('visibilitychange', onVisibilityChange);
-      window.removeEventListener('focus', onFocus);
+    onMounted(() => {
+      if (visibility.value !== 'hidden') {
+        resume();
+      }
     });
   }
 

--- a/app/features/profile/activation/model/consts.ts
+++ b/app/features/profile/activation/model/consts.ts
@@ -18,18 +18,28 @@ export const SUBSCRIPTION_MY_CODES_DATA_KEY = 'subscription-my-codes';
 export const SUBSCRIPTION_MY_REWARDS_DATA_KEY = 'subscription-my-rewards';
 
 /**
- * Ключи «живых» данных для фонового опроса: статус подписки и перки — это блок
- * статуса вверху профиля и бейдж/значок/цвет ника в сайдбаре. Список кодов сюда
- * НЕ входит: он меняется только при погашении и обновляется точечно (refreshAll),
- * чтобы фоновый опрос не дёргал историю кодов.
+ * «Живые» данные фонового опроса — статус подписки и перки (блок статуса вверху
+ * профиля и бейдж/значок/цвет ника в сайдбаре). Список кодов сюда НЕ входит: он
+ * меняется только при погашении и обновляется точечно (refreshAll), чтобы фоновый
+ * опрос не дёргал историю кодов. Обновляются через refresh() своих composable
+ * (общий ключ useAsyncData) — см. useSubscriptionAutoRefresh.
  */
-export const SUBSCRIPTION_LIVE_DATA_KEYS = [
-  SUBSCRIPTION_MY_DATA_KEY,
-  SUBSCRIPTION_MY_REWARDS_DATA_KEY,
-];
 
 /** Интервал авто-обновления статуса подписки без F5 (мс). */
 export const SUBSCRIPTION_POLL_INTERVAL_MS = 30_000;
+
+/**
+ * Минимальный интервал между любыми двумя обновлениями (мс). Защита от «спама»
+ * при частом переключении вкладок/окон (focus/visibility) — как cooldown у
+ * online-heartbeat: серия возвратов на вкладку не выдаёт пачку запросов.
+ */
+export const SUBSCRIPTION_POLL_COOLDOWN_MS = 10_000;
+
+/**
+ * Потолок экспоненциального backoff при ответе 429 (слишком много запросов).
+ * Пока сервер лимитирует — опрашиваем реже, чтобы не «залипать» в rate-limit.
+ */
+export const SUBSCRIPTION_POLL_MAX_BACKOFF_MS = 5 * 60_000;
 
 /** Эндпоинт активации подписки (запуск таймера REGISTERED→ACTIVE). */
 export function subscriptionActivatePath(id: string): string {

--- a/app/features/profile/activation/model/consts.ts
+++ b/app/features/profile/activation/model/consts.ts
@@ -75,6 +75,22 @@ export const REWARD_PERK_ICONS: Record<RewardPerk, string> = {
   APP_CREDITS: 'tabler:award',
 };
 
+/**
+ * Готовые S3-загрузки наград — фолбэк, пока бэкенд не проставил `url` в
+ * reward_resource. Ключ отдаётся прокси core-app `/s3/<key>`. Если админ позже
+ * задаст url на бэке — приоритет у бэкенда (см. RewardLinkRow).
+ */
+export const REWARD_PERK_FALLBACK_URLS: Partial<Record<RewardPerk, string>> = {
+  MAP_TOKENS_DOWNLOAD: '/s3/vttgw/rewards/CardsAndTokens.zip',
+};
+
+/**
+ * Изображение рамки аватара (косметический перк AVATAR_FRAME) — накладывается
+ * поверх аватара в сайдбаре профиля, если перк выдан кодом. Ключ отдаётся прокси
+ * core-app `/s3/<key>` (как остальные S3-ассеты).
+ */
+export const AVATAR_FRAME_IMAGE_URL = '/s3/vttgw/rewards/frame.webp';
+
 /** Перки-«загрузки» — для них уместна кнопка «Скачать» (иначе «Открыть»). */
 export const DOWNLOAD_PERKS: ReadonlySet<RewardPerk> = new Set<RewardPerk>([
   'EARLY_ACCESS_DOWNLOAD',

--- a/app/features/profile/activation/ui/RewardLinkRow.vue
+++ b/app/features/profile/activation/ui/RewardLinkRow.vue
@@ -3,6 +3,7 @@
 
   import {
     COSMETIC_PERKS,
+    REWARD_PERK_FALLBACK_URLS,
     REWARD_PERK_ICONS,
     REWARD_PERK_LABELS,
     rewardActionIcon,
@@ -23,8 +24,14 @@
     () => props.reward.availability === 'COMING_SOON',
   );
 
-  // Ссылка кликабельна, только если контент готов и URL задан админом.
-  const hasLink = computed(() => !isComingSoon.value && !!props.reward.url);
+  // URL награды: приоритет у бэкенда (reward_resource), иначе готовый S3-фолбэк.
+  const url = computed(
+    () =>
+      props.reward.url ?? REWARD_PERK_FALLBACK_URLS[props.reward.perk] ?? null,
+  );
+
+  // Ссылка кликабельна, только если контент готов и есть URL (бэкенд или фолбэк).
+  const hasLink = computed(() => !isComingSoon.value && !!url.value);
 
   // Косметический перк — ссылки нет по дизайну, он просто применён к профилю.
   const isCosmetic = computed(() => COSMETIC_PERKS.has(props.reward.perk));
@@ -55,7 +62,7 @@
 
     <UButton
       v-if="hasLink"
-      :to="reward.url!"
+      :to="url!"
       target="_blank"
       rel="noopener noreferrer"
       :icon="rewardActionIcon(reward.perk)"

--- a/app/features/profile/sidebar/ui/ProfileAvatar.vue
+++ b/app/features/profile/sidebar/ui/ProfileAvatar.vue
@@ -1,9 +1,17 @@
 <script setup lang="ts">
   import type { UserProfile } from '~/shared/types';
 
+  import { useMyRewards } from '~profile/activation/composables';
+  import { AVATAR_FRAME_IMAGE_URL } from '~profile/activation/model';
+
   defineProps<{
     profile?: UserProfile;
   }>();
+
+  const { hasPerk } = useMyRewards();
+
+  // Рамка аватара — косметический перк AVATAR_FRAME, выданный кодом.
+  const hasAvatarFrame = computed(() => hasPerk('AVATAR_FRAME'));
 </script>
 
 <template>
@@ -19,6 +27,15 @@
       :alt="profile?.username"
       size="3xl"
       class="relative z-10 h-32 w-32 text-4xl shadow-2xl ring-4 ring-default transition-transform duration-200 group-active:scale-95"
+    />
+
+    <!-- Рамка аватара (перк AVATAR_FRAME из кода) — оверлей поверх аватара -->
+    <img
+      v-if="hasAvatarFrame"
+      :src="AVATAR_FRAME_IMAGE_URL"
+      alt=""
+      aria-hidden="true"
+      class="pointer-events-none absolute inset-0 z-10 h-full w-full scale-[1.35] object-contain"
     />
 
     <UButton

--- a/app/features/user/helmet/UserHelmet.vue
+++ b/app/features/user/helmet/UserHelmet.vue
@@ -107,7 +107,10 @@
       #content
     >
       <div class="flex flex-col">
-        <UserInfo :user />
+        <UserInfo
+          :user
+          @open-profile="openProfile"
+        />
 
         <USeparator />
 

--- a/app/features/user/helmet/ui/UserInfo.vue
+++ b/app/features/user/helmet/ui/UserInfo.vue
@@ -1,9 +1,26 @@
 <script setup lang="ts">
   import type { UserProfile } from '~/shared/types';
 
+  import { useMyRewards } from '~profile/activation/composables';
+  import { AVATAR_FRAME_IMAGE_URL } from '~profile/activation/model';
+
   defineProps<{
     user: UserProfile;
   }>();
+
+  const emit = defineEmits<{
+    'open-profile': [];
+  }>();
+
+  const { hasPerk } = useMyRewards();
+
+  // Рамка аватара — косметический перк AVATAR_FRAME, выданный кодом.
+  const hasAvatarFrame = computed(() => hasPerk('AVATAR_FRAME'));
+
+  // Клик по аватару открывает профиль; меню закрывает родитель (там состояние поповера).
+  function openProfile() {
+    emit('open-profile');
+  }
 </script>
 
 <template>
@@ -22,10 +39,24 @@
       </div>
     </div>
 
-    <UAvatar
-      :alt="user.username"
-      size="3xl"
-      :ui="{ fallback: 'uppercase' }"
-    />
+    <div
+      class="relative shrink-0 cursor-pointer"
+      @click.left.exact.prevent="openProfile"
+    >
+      <UAvatar
+        :alt="user.username"
+        size="3xl"
+        :ui="{ fallback: 'uppercase' }"
+      />
+
+      <!-- Рамка аватара (перк AVATAR_FRAME из кода) — оверлей поверх аватара -->
+      <img
+        v-if="hasAvatarFrame"
+        :src="AVATAR_FRAME_IMAGE_URL"
+        alt=""
+        aria-hidden="true"
+        class="pointer-events-none absolute inset-0 z-10 h-full w-full scale-[1.35] object-contain"
+      />
+    </div>
   </div>
 </template>


### PR DESCRIPTION
Две связанные доработки раздела профиля «Подписки / Коды» и наград по кодам.

## 1. Награды по кодам: скачивание, рамка аватара, вход в профиль (feat)

### Кнопка «Скачать» для наград-загрузок
- В карточке погашенного кода у награды «Карты и токены» (перк `MAP_TOKENS_DOWNLOAD`) появилась рабочая кнопка «Скачать».
- Пока бэкенд не проставил ссылку в `reward_resource`, берётся готовый файл на S3 (`/s3/vttgw/rewards/CardsAndTokens.zip`) через прокси core-app `/s3/<key>`.
- Приоритет остаётся за ссылкой из бэкенда (self-healing: как только админ задаст `url`, возьмётся он). Фолбэк не показывается для наград со статусом `COMING_SOON`.

### Рамка аватара (перк `AVATAR_FRAME`)
- Если рамка выдана кодом, поверх аватара накладывается изображение `frame.webp` с S3 (`/s3/vttgw/rewards/frame.webp`).
- Добавлена в двух местах: большой аватар в личном кабинете (`ProfileAvatar`) и аватар в меню профиля (`UserInfo`).
- Оверлей абсолютный, `pointer-events-none`, без сдвига вёрстки; наличие перка берётся из общего `useMyRewards` (тот же `useAsyncData`-ключ — без лишних запросов).

### Меню профиля
- Клик по аватару в меню открывает страницу профиля (+ курсор-указатель). Навигация с закрытием меню выполняется в `UserHelmet` через событие (переиспользуется существующий `openProfile`).

Все ссылки на ассеты вынесены в константы (`REWARD_PERK_FALLBACK_URLS`, `AVATAR_FRAME_IMAGE_URL`), без хардкода в компонентах.

## 2. Фоновый опрос статуса подписки без упора в rate-limit (fix)

Раздел держит статус подписки и перки актуальными фоновым опросом (`useSubscriptionAutoRefresh`). Прежний наивный `setInterval` при долго открытой вкладке сам загонял фронт в ошибку 429 (на сервере стоит защитный rate-limit). Переписано по образцу проверенного в проекте `online-heartbeat`:

- **Пауза на скрытой вкладке** (`useIntervalFn` + `useDocumentVisibility`): фоновая вкладка не шлёт запросы, при возврате — одно обновление. Проверка видимости на всех путях (таймер, focus, visibilitychange).
- **Cooldown 10 c** между любыми обновлениями: всплеск focus/visibilitychange при переключении окон больше не выдаёт пачку запросов.
- **Экспоненциальный backoff на 429** (30 c → … → потолок 5 мин, сброс при успехе).
- **Single-flight**: новый опрос не стартует поверх незавершённого.
- Источники `useMySubscriptions`/`useMyRewards` ходят с `retry: 0` — ofetch не удваивает запрос авто-ретраем на 429.
- Таймер и слушатели чистятся через scope-dispose VueUse.

Кадэнс на переднем плане прежний (30 c); фоновая/свёрнутая вкладка и всплески от переключения окон больше не набивают лимит.

## Затронутые файлы
- `composables/useSubscriptionAutoRefresh.ts` — переписан поллер
- `composables/useMyRewards.ts`, `composables/useMySubscriptions.ts` — `retry: 0`
- `model/consts.ts` — константы опроса + URL ассетов наград
- `ui/RewardLinkRow.vue` — кнопка «Скачать»
- `sidebar/ui/ProfileAvatar.vue`, `helmet/ui/UserInfo.vue` — рамка аватара; `UserInfo.vue` — клик по аватару
- `helmet/UserHelmet.vue` — обработка открытия профиля из меню

## Проверка
- `vue-tsc -p tsconfig.json` — зелёный
- `eslint` — зелёный (pre-commit хук: eslint + vue-tsc + stylelint)

