### PR TITLE
feat(home): обновить баннеры на главной

### DIFF
--- a/app/features/home/banners/HomeBanners.vue
+++ b/app/features/home/banners/HomeBanners.vue
@@ -3,10 +3,6 @@
 
   import { BannerCard } from './ui';
 
-  defineProps<{
-    group: 'tools' | 'info';
-  }>();
-
   const overlay = useOverlay();
 
   const multiclassDrawer = overlay.create(MulticlassDrawer, {
@@ -24,35 +20,25 @@
 </script>
 
 <template>
-  <template v-if="group === 'tools'">
-    <BannerCard
-      title="Создание мультикласса"
-      background-url="/s3/home/multiclassing-banner.webp"
-      description="Собери уникальную комбинацию классов"
-      @click="multiclassDrawer.open()"
-    />
+  <BannerCard
+    title="Токенатор"
+    to="/tokenator"
+    background-url="/s3/home/tokenator-banner.webp"
+    description="Создай уникальный токен персонажа!"
+    class="col-span-2 min-h-24 justify-center"
+  />
 
-    <BannerCard
-      title="Калькулятор характеристик"
-      to="/calculators/abilities"
-      background-url="/s3/home/calculator-abilities-banner.webp"
-      description="Идеальный баланс твоего персонажа"
-    />
-  </template>
+  <BannerCard
+    title="Создание мультикласса"
+    background-url="/s3/home/multiclassing-banner.webp"
+    description="Собери уникальную комбинацию классов"
+    @click="multiclassDrawer.open()"
+  />
 
-  <template v-else-if="group === 'info'">
-    <BannerCard
-      title="Токенатор"
-      to="/tokenator"
-      background-url="/s3/home/tokenator-banner.webp"
-      description="Создай уникальный токен персонажа!"
-    />
-
-    <BannerCard
-      title="Дорожная карта"
-      to="/roadmap"
-      background-url="/s3/home/roadmap-banner.webp"
-      description="Выбор за тобой!"
-    />
-  </template>
+  <BannerCard
+    title="Калькулятор характеристик"
+    to="/calculators/abilities"
+    background-url="/s3/home/calculator-abilities-banner.webp"
+    description="Идеальный баланс твоего персонажа"
+  />
 </template>

--- a/app/features/home/banners/VttgCampaignBanner.vue
+++ b/app/features/home/banners/VttgCampaignBanner.vue
@@ -6,8 +6,7 @@
   <div
     :class="[
       'vttg-banner',
-      'relative flex w-full flex-col gap-6 overflow-hidden rounded-2xl border p-6 shadow-xl md:p-8',
-      'md:flex-row md:items-center md:justify-between lg:gap-8',
+      'relative flex w-full flex-col overflow-hidden rounded-2xl border shadow-xl',
     ]"
   >
     <!-- Background image and overlay -->
@@ -22,64 +21,84 @@
       <div class="vttg-banner__overlay absolute inset-0" />
     </div>
 
-    <!-- Content -->
-    <div class="relative z-10 flex flex-1 flex-col items-start gap-3">
-      <h2 class="text-xl font-bold tracking-tight text-white md:text-2xl">
-        {{ VTTG_CAMPAIGN_BANNER.title }}
-      </h2>
+    <!-- Top strip -->
+    <div
+      class="vttg-banner__strip relative z-10 flex items-center justify-center gap-2 px-4 py-2.5 md:py-3"
+    >
+      <UIcon
+        :name="VTTG_CAMPAIGN_BANNER.stripIcon"
+        class="size-4 shrink-0 md:size-5"
+      />
 
-      <p
-        class="max-w-3xl text-sm leading-relaxed text-neutral-300 md:text-base"
-      >
-        {{ VTTG_CAMPAIGN_BANNER.description }}
-      </p>
+      <span class="text-xs font-semibold tracking-wide uppercase md:text-sm">
+        {{ VTTG_CAMPAIGN_BANNER.stripText }}
+      </span>
     </div>
 
-    <!-- Actions -->
+    <!-- Body -->
     <div
-      class="relative z-10 flex shrink-0 flex-wrap items-center gap-3 sm:flex-nowrap"
+      :class="[
+        'relative z-10 flex flex-col gap-6 p-6 md:p-8',
+        'md:flex-row md:items-center md:justify-between lg:gap-8',
+      ]"
     >
-      <UButton
-        :to="VTTG_CAMPAIGN_BANNER.moreInfoTo"
-        color="neutral"
-        variant="subtle"
-        size="lg"
-        class="w-full vttg-btn-secondary sm:w-auto"
-        :style="{
-          '--btn-border':
-            'color-mix(in oklch, var(--vttg-gold) 35%, transparent)',
-          '--btn-text': 'var(--vttg-gold)',
-          '--btn-bg': 'color-mix(in oklch, var(--vttg-gold) 8%, transparent)',
-        }"
-      >
-        Подробнее
-        <template #trailing>
-          <UIcon
-            name="tabler:arrow-right"
-            class="size-4"
-          />
-        </template>
-      </UButton>
+      <!-- Content -->
+      <div class="flex flex-1 flex-col items-start gap-3">
+        <h2 class="text-xl font-bold tracking-tight text-white md:text-2xl">
+          {{ VTTG_CAMPAIGN_BANNER.title }}
+        </h2>
 
-      <UButton
-        :to="VTTG_CAMPAIGN_BANNER.linkTo"
-        target="_blank"
-        color="primary"
-        size="lg"
-        class="w-full vttg-btn-primary sm:w-auto"
-        :style="{
-          '--btn-bg': 'var(--vttg-gold)',
-          '--btn-text': 'var(--ui-bg)',
-        }"
-      >
-        <template #leading>
-          <UIcon
-            name="tabler:heart"
-            class="size-4"
-          />
-        </template>
-        Поддержать проект
-      </UButton>
+        <p
+          class="max-w-3xl text-sm leading-relaxed text-neutral-300 md:text-base"
+        >
+          {{ VTTG_CAMPAIGN_BANNER.description }}
+        </p>
+      </div>
+
+      <!-- Actions -->
+      <div class="flex shrink-0 flex-wrap items-center gap-3 sm:flex-nowrap">
+        <UButton
+          :to="VTTG_CAMPAIGN_BANNER.moreInfoTo"
+          color="neutral"
+          variant="subtle"
+          size="lg"
+          class="w-full vttg-btn-secondary sm:w-auto"
+          :style="{
+            '--btn-border':
+              'color-mix(in oklch, var(--vttg-gold) 35%, transparent)',
+            '--btn-text': 'var(--vttg-gold)',
+            '--btn-bg': 'color-mix(in oklch, var(--vttg-gold) 8%, transparent)',
+          }"
+        >
+          Подробнее
+          <template #trailing>
+            <UIcon
+              name="tabler:arrow-right"
+              class="size-4"
+            />
+          </template>
+        </UButton>
+
+        <UButton
+          :to="VTTG_CAMPAIGN_BANNER.linkTo"
+          target="_blank"
+          color="primary"
+          size="lg"
+          class="w-full vttg-btn-primary sm:w-auto"
+          :style="{
+            '--btn-bg': 'var(--vttg-gold)',
+            '--btn-text': 'var(--ui-bg)',
+          }"
+        >
+          <template #leading>
+            <UIcon
+              name="tabler:heart"
+              class="size-4"
+            />
+          </template>
+          Поддержать проект
+        </UButton>
+      </div>
     </div>
   </div>
 </template>
@@ -106,6 +125,13 @@
 
   .vttg-banner__bg {
     transition: transform 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  .vttg-banner__strip {
+    color: var(--ui-bg);
+    background-color: var(--vttg-gold);
+    box-shadow: 0 2px 12px -4px
+      color-mix(in oklch, var(--vttg-gold) 60%, transparent);
   }
 
   .vttg-banner__overlay {

--- a/app/features/home/banners/model/constants.ts
+++ b/app/features/home/banners/model/constants.ts
@@ -5,4 +5,6 @@ export const VTTG_CAMPAIGN_BANNER = {
   backgroundImage: '/s3/home/vttg-banner.webp',
   linkTo: 'https://crowdrepublic.ru/projects/1073013',
   moreInfoTo: '/vttg',
+  stripText: 'Идёт сбор средств на CrowdRepublic',
+  stripIcon: 'tabler:heart-handshake',
 } as const;

--- a/app/features/home/link-to-5e14/LinkTo5e14.vue
+++ b/app/features/home/link-to-5e14/LinkTo5e14.vue
@@ -4,23 +4,25 @@
     :class="[
       'relative flex flex-1 flex-col gap-3 bg-muted p-3',
       'rounded-[10px] border border-default shadow-lg',
-      'overflow-hidden text-default no-underline',
+      'overflow-hidden text-white no-underline',
       'before:absolute before:inset-0',
       'before:block before:size-full',
       'before:bg-[url(/s3/home/legacy-site.webp)] before:opacity-40',
       'before:bg-cover before:bg-center before:bg-no-repeat',
       'before:transition-transform before:duration-200',
       'hover:before:scale-115',
+      'after:absolute after:inset-0 after:block after:size-full',
+      'after:bg-linear-to-t after:from-black/70 after:to-black/40',
     ]"
     target="_blank"
   >
     <h2
-      class="relative z-10 text-2xl font-semibold text-default [text-shadow:0_2px_4px_#0000006e]"
+      class="relative z-10 text-2xl font-semibold text-white [text-shadow:0_2px_4px_#0000006e]"
     >
       D&D 2014
     </h2>
 
-    <p class="relative z-10 text-default [text-shadow:0_2px_4px_#0000006e]">
+    <p class="relative z-10 text-white [text-shadow:0_2px_4px_#0000006e]">
       Предыдущая редакция Dungeon and Dragons
     </p>
   </NuxtLink>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -39,9 +39,7 @@
         <!-- Навигация по сайту и соцсети -->
         <div class="flex w-full flex-col gap-3 xl:w-1/3 2xl:w-1/3">
           <div class="grid grid-cols-2 gap-3">
-            <HomeBanners group="tools" />
-
-            <HomeBanners group="info" />
+            <HomeBanners />
           </div>
 
           <SocialLinks />


### PR DESCRIPTION
- VTTG-баннер: добавлена толстая золотая полоса сверху с текстом о сборе средств; текст и иконка вынесены в конфиг VTTG_CAMPAIGN_BANNER
- карточка «D&D 2014»: текст сделан белым и добавлен тёмный полупрозрачный слой поверх фона для читаемости в светлой теме
- блок инструментов: удалена карточка «Дорожная карта»; «Токенатор» вынесен в первую строку на всю ширину, стал выше и центрирован по вертикали; «Создание мультикласса» и «Калькулятор характеристик» — во второй строке
- удалён неиспользуемый проп group у HomeBanners, сетка возвращена к двум колонкам