### PR TITLE
fix(markup-editor): не терять текст после таблицы/списка/цитаты при открытии в редакторе

### DIFF
--- a/app/shared/ui/markup-editor/tiptap/block-tokenizer.ts
+++ b/app/shared/ui/markup-editor/tiptap/block-tokenizer.ts
@@ -9,6 +9,37 @@ import { findMarkerEnd } from '../../markup/balance';
 /** Пустая полезная нагрузка токена (блок-чипу нужны только type+raw). */
 const EMPTY_DATA: Record<string, never> = {};
 
+/** Инлайн-токены содержимого блока, вычисляемые ЛЕНИВО (на фазе parseMarkdown). */
+export type DeferredInlineTokens = () => MarkdownToken[];
+
+/**
+ * Откладывает инлайн-токенизацию содержимого блочного маркера (ячейки таблицы,
+ * пункта списка, абзаца цитаты) до фазы `parseMarkdown` вместо немедленного
+ * вызова `lexer.inlineTokens(...)` внутри токенайзера.
+ *
+ * ПОЧЕМУ это обязательно (иначе теряется текст ПОСЛЕ таблицы/списка/цитаты):
+ * `@tiptap/markdown` передаёт блочному токенайзеру `lexer`, чей `inlineTokens`
+ * ходит в ОТДЕЛЬНЫЙ постоянный marked-Lexer менеджера, а НЕ в транзитный лексер,
+ * который прямо сейчас лексит документ. Оба Lexer'а делят ОДИН объект Tokenizer,
+ * а `inlineTokens`/`blockTokens` внутри делают `tokenizer.lexer = this`. Значит
+ * вызов `lexer.inlineTokens` во время блочной токенизации перенаводит общий
+ * токенайзер на лексер менеджера. После этого КАЖДЫЙ следующий абзац документа
+ * встаёт в `inlineQueue` лексера менеджера, который в этом проходе никогда не
+ * сливается (`lex()` сливает очередь ТРАНЗИТНОГО лексера) → инлайн-содержимое
+ * таких абзацев молча теряется (абзац приходит пустым).
+ *
+ * `parseMarkdown` вызывается уже из `parseTokens`, когда весь документ разобран
+ * на блоки: лексинг завершён, перенаводить общий токенайзер не на что, поэтому
+ * ленивый `lexer.inlineTokens(source)` безопасен. НЕ вызывать `lexer.inlineTokens`
+ * из `buildData`.
+ */
+export function deferInline(
+  lexer: MarkdownLexerConfiguration,
+  source: string,
+): DeferredInlineTokens {
+  return () => lexer.inlineTokens(source);
+}
+
 /**
  * Читает имя маркера `{@name …}` (до пробела/`}`) и сверяет со списком имён.
  * Так `{@listfoo}` не пройдёт за `{@list`. Единый предикат для isList/isTable/

--- a/app/shared/ui/markup-editor/tiptap/ttg-list.ts
+++ b/app/shared/ui/markup-editor/tiptap/ttg-list.ts
@@ -9,6 +9,8 @@ import type {
 
 import type { MarkerNode, RenderNode } from '~ui/markup';
 
+import type { DeferredInlineTokens } from './block-tokenizer';
+
 import { Extension } from '@tiptap/core';
 import { BulletList, ListItem, OrderedList } from '@tiptap/extension-list';
 
@@ -16,6 +18,7 @@ import { isMarkerNode, parse, serializeMarkup } from '~ui/markup';
 
 import {
   createBlockMarkerTokenizer,
+  deferInline,
   markerNameMatches,
 } from './block-tokenizer';
 
@@ -28,10 +31,10 @@ const LIST_TOKEN = 'ttgList';
 /** Имена списочного маркера (алиасов у {@list} нет). */
 const LIST_NAMES = new Set(['list']);
 
-/** Разобранный пункт списка: инлайн-токены абзаца + вложенные списки. */
+/** Разобранный пункт списка: ленивые инлайн-токены абзаца + вложенные списки. */
 interface TtgListItemData {
-  /** Инлайн-токены содержимого пункта (→ узлы абзаца через parseInline). */
-  tokens: MarkdownToken[];
+  /** Ленивые инлайн-токены содержимого пункта (→ узлы абзаца через parseInline). */
+  tokens: DeferredInlineTokens;
   /** Вложенные списки, прикреплённые к этому пункту (как в MarkupList). */
   children: TtgListData[];
 }
@@ -91,14 +94,17 @@ function listNodeToData(
       if (last) {
         last.children.push(nested);
       } else {
-        items.push({ tokens: [], children: [nested] });
+        items.push({ tokens: () => [], children: [nested] });
       }
 
       continue;
     }
 
     // Пункт {@li ...} (или батч-массив из бэкенд-AST) — один <li>.
-    items.push({ tokens: lexer.inlineTokens(itemInner(child)), children: [] });
+    items.push({
+      tokens: deferInline(lexer, itemInner(child)),
+      children: [],
+    });
   }
 
   return { ordered, items };
@@ -144,7 +150,7 @@ function listItemToJSON(
 ): JSONContent {
   const paragraph: JSONContent = {
     type: 'paragraph',
-    content: helpers.parseInline(item.tokens),
+    content: helpers.parseInline(item.tokens()),
   };
 
   return {

--- a/app/shared/ui/markup-editor/tiptap/ttg-quote.ts
+++ b/app/shared/ui/markup-editor/tiptap/ttg-quote.ts
@@ -8,6 +8,8 @@ import type {
 
 import type { MarkerNode, RenderNode } from '~ui/markup';
 
+import type { DeferredInlineTokens } from './block-tokenizer';
+
 import { Extension } from '@tiptap/core';
 import { Blockquote } from '@tiptap/extension-blockquote';
 
@@ -15,6 +17,7 @@ import { isMarkerNode, parse, serializeMarkup } from '~ui/markup';
 
 import {
   createBlockMarkerTokenizer,
+  deferInline,
   markerNameMatches,
 } from './block-tokenizer';
 import { dataAttr } from './node-utils';
@@ -24,9 +27,9 @@ const QUOTE_TOKEN = 'ttgQuote';
 /** Имена маркеров, обозначающих цитату (алиасы из markup/config.ts). */
 const QUOTE_NAMES = new Set(['quote', 'blockquote', 'q']);
 
-/** Разобранная цитата: абзацы (инлайн-токены) + атрибуты оформления. */
+/** Разобранная цитата: абзацы (ленивые инлайн-токены) + атрибуты оформления. */
 interface QuoteData {
-  paragraphs: { tokens: MarkdownToken[] }[];
+  paragraphs: { tokens: DeferredInlineTokens }[];
   color?: string;
   variant?: string;
 }
@@ -122,7 +125,7 @@ function buildQuoteData(
   const groups = groupParagraphs(node.content ?? []);
 
   const paragraphs = (groups.length ? groups : [[]]).map((group) => ({
-    tokens: lexer.inlineTokens(serializeInline(group)),
+    tokens: deferInline(lexer, serializeInline(group)),
   }));
 
   return {
@@ -161,7 +164,7 @@ export const TtgQuoteMarkdown = Extension.create({
       { color: data.color ?? null, variant: data.variant ?? null },
       data.paragraphs.map((paragraph) => ({
         type: 'paragraph',
-        content: helpers.parseInline(paragraph.tokens),
+        content: helpers.parseInline(paragraph.tokens()),
       })),
     );
   },

--- a/app/shared/ui/markup-editor/tiptap/ttg-table.ts
+++ b/app/shared/ui/markup-editor/tiptap/ttg-table.ts
@@ -8,6 +8,8 @@ import type {
 
 import type { MarkerNode, RenderNode } from '~ui/markup';
 
+import type { DeferredInlineTokens } from './block-tokenizer';
+
 import { Extension } from '@tiptap/core';
 import {
   Table,
@@ -25,6 +27,7 @@ import {
 
 import {
   createBlockMarkerTokenizer,
+  deferInline,
   markerNameMatches,
 } from './block-tokenizer';
 import { dataAttr } from './node-utils';
@@ -48,10 +51,10 @@ interface ParsedTable extends MarkerNode {
   rows?: ParsedCell[][];
 }
 
-/** Разобранная ячейка редактора: инлайн-токены + атрибуты. */
+/** Разобранная ячейка редактора: ленивые инлайн-токены + атрибуты. */
 interface CellData {
   isHeader: boolean;
-  tokens: MarkdownToken[];
+  tokens: DeferredInlineTokens;
   style?: string;
   align?: string;
 }
@@ -113,7 +116,7 @@ function buildTableData(
     cells.push(
       colLabels.map((label, index) => ({
         isHeader: true,
-        tokens: lexer.inlineTokens(serializeInline(toArray(label))),
+        tokens: deferInline(lexer, serializeInline(toArray(label))),
         style: colStyles[index] || undefined,
         align: colAligns[index] || undefined,
       })),
@@ -124,7 +127,7 @@ function buildTableData(
     cells.push(
       row.map((cell) => ({
         isHeader: false,
-        tokens: lexer.inlineTokens(serializeInline(cell.content ?? [])),
+        tokens: deferInline(lexer, serializeInline(cell.content ?? [])),
         align: cell.align,
       })),
     );
@@ -165,7 +168,12 @@ export const TtgTableMarkdown = Extension.create({
           helpers.createNode(
             cell.isHeader ? 'tableHeader' : 'tableCell',
             { style: cell.style ?? null, align: cell.align ?? null },
-            [{ type: 'paragraph', content: helpers.parseInline(cell.tokens) }],
+            [
+              {
+                type: 'paragraph',
+                content: helpers.parseInline(cell.tokens()),
+              },
+            ],
           ),
         ),
       ),


### PR DESCRIPTION
При загрузке описания в MarkupEditor абзацы, идущие ПОСЛЕ блока {@table}/{@list}/{@quote}, приходили пустыми — текст молча пропадал (на сайте при этом отображался верно, баг только в редакторе на слое разбора markdown → doc).

Причина: блочные токенайзеры таблицы/списка/цитаты вызывали lexer.inlineTokens(...) прямо во время блочной токенизации документа. В @tiptap/markdown этот inlineTokens ходит в отдельный постоянный marked-Lexer менеджера, который делит один объект Tokenizer с активным лексером; inlineTokens/blockTokens внутри делают tokenizer.lexer = this, то есть вызов перенаводит общий токенайзер на лексер менеджера. После этого каждый следующий абзац документа встаёт в inlineQueue менеджерского лексера, который в текущем проходе не сливается, — инлайн-содержимое абзаца теряется (приходит пустой paragraph).

Инлайн-токенизация содержимого ячеек/пунктов/абзацев отложена до фазы parseMarkdown (вызывается из parseTokens уже после лексинга, перенаводить общий токенайзер не на что): добавлен помощник deferInline в block-tokenizer.ts, поля tokens в ttg-table/ttg-list/ttg-quote переведены на ленивое вычисление () => MarkdownToken[]. lexer.inlineTokens больше не вызывается из buildData.

Проверено на реальном MarkdownManager.parse: хвост выживает после table/list/quote (в т.ч. со вложенными таблицами/списками в ячейках), инлайн-контент ячеек/пунктов/цитат (марки, markdown, чипы {@...}) цел, round-trip стабилен; vue-tsc и eslint чисто.