### PR TITLE
fix(reset-password): проверка токена при открытии страницы и понятные ошибки

### DIFF
--- a/app/features/user/auth-modal/ui/ChangePassword.vue
+++ b/app/features/user/auth-modal/ui/ChangePassword.vue
@@ -31,7 +31,9 @@
     if (error.value) {
       toast.add({
         title: 'Ошибка восстановления пароля',
-        description: error.value.data.message,
+        description:
+          error.value.data?.message
+          ?? 'Не удалось отправить письмо — попробуйте ещё раз.',
         color: 'error',
         icon: 'tabler:user-exclamation',
       });

--- a/app/pages/reset-password.vue
+++ b/app/pages/reset-password.vue
@@ -12,6 +12,24 @@
     throw createError(getErrorResponse(StatusCodes.BAD_REQUEST));
   }
 
+  // Проверяем токен сразу при открытии страницы, чтобы не заставлять
+  // пользователя вводить пароль ради протухшей ссылки.
+  const { status: tokenCheckStatus, error: tokenCheckError } = useFetch(
+    '/api/auth/password/reset-token/validate',
+    {
+      query: { token: passwordResetToken },
+      retry: false,
+    },
+  );
+
+  const tokenInvalid = computed(() => tokenCheckStatus.value === 'error');
+
+  const tokenInvalidMessage = computed(
+    () =>
+      tokenCheckError.value?.data?.message
+      ?? 'Ссылка для сброса пароля недействительна — запросите новую.',
+  );
+
   const state = reactive({
     newPassword: '',
     repeatPassword: '',
@@ -74,7 +92,9 @@
     if (error.value) {
       toast.add({
         title: 'Ошибка сброса пароля',
-        description: error.value.data.message,
+        description:
+          error.value.data?.message
+          ?? 'Не удалось сбросить пароль — попробуйте ещё раз.',
         color: 'error',
         icon: 'tabler:user-exclamation',
       });
@@ -113,12 +133,33 @@
       <div class="flex flex-col gap-2">
         <h1 class="text-2xl font-semibold text-primary">Сброс пароля</h1>
 
-        <p class="text-sm text-secondary">
+        <p
+          v-if="tokenInvalid"
+          class="text-sm text-error"
+        >
+          {{ tokenInvalidMessage }}
+        </p>
+
+        <p
+          v-else
+          class="text-sm text-secondary"
+        >
           Введите новый пароль для вашей учетной записи.
         </p>
       </div>
 
+      <UButton
+        v-if="tokenInvalid"
+        class="md:w-auto"
+        variant="soft"
+        block
+        @click.left.exact.prevent="navigateToHome"
+      >
+        На главную
+      </UButton>
+
       <UForm
+        v-else
         class="flex flex-col gap-4"
         :state
         @submit.prevent.stop="onSubmit"

--- a/server/api/auth/password/reset-token/validate.get.ts
+++ b/server/api/auth/password/reset-token/validate.get.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+import {
+  createAuthValidationError,
+  fetchAuthService,
+} from '#server/utils/authService';
+
+const validateQuerySchema = z.object({
+  token: z.string().min(1),
+});
+
+export default defineEventHandler(async (event) => {
+  const parsedQuery = validateQuerySchema.safeParse(getQuery(event));
+
+  if (!parsedQuery.success) {
+    throw createAuthValidationError();
+  }
+
+  await fetchAuthService<unknown>(
+    '/api/account/password/reset-token/validate',
+    {
+      method: 'GET',
+      query: { token: parsedQuery.data.token },
+    },
+  );
+
+  return null;
+});


### PR DESCRIPTION
## Контекст

Пользователи жаловались на «Неизвестную ошибку» при восстановлении пароля. Корень — auth-service отдавал 500 без сообщения для невалидного/использованного/истёкшего токена, чинится в TTG-Club/auth-service#11. Этот PR — сторона core-app.

## Что сделано

- Новый прокси-роут `GET /api/auth/password/reset-token/validate` к auth-service (аналогично существующим reset-request/reset-confirm).
- Страница `/reset-password` проверяет токен сразу при открытии: если ссылка протухла/уже использована, вместо формы показывается сообщение сервера и кнопка «На главную» — пользователь больше не вводит новый пароль дважды впустую, чтобы узнать об этом только после сабмита.
- Тосты ошибок в `reset-password.vue` и `ChangePassword.vue` (auth-modal) читают `error.value.data?.message` с запасным текстом: раньше при обрыве сети доступ `data.message` кидал TypeError и тост не показывался вовсе.

Сообщения приходят из auth-service («Срок действия ссылки для сброса пароля истёк — запросите новую» и т.п.) через существующий механизм `getAuthServiceErrorMessage` — до деплоя auth-service#11 будет запасной текст.

## Проверка

`npm run type-check` проходит; eslint/vue-tsc/stylelint отработали в pre-commit хуке.

🤖 Generated with [Claude Code](https://claude.com/claude-code)