### PR TITLE
feat(profile): отображаемое имя пользователя вместо логина

### DIFF
--- a/app/composables/useCommentsNameSync.ts
+++ b/app/composables/useCommentsNameSync.ts
@@ -1,0 +1,16 @@
+const COMMENTS_NAME_SYNC_API_PATH = '/api/user/comments/sync-name';
+
+/**
+ * Синхронизация имени автора в комментариях с текущим отображаемым именем.
+ * Best-effort и fire-and-forget: зовётся после смены имени и после публикации
+ * комментария; ошибки проглатываются — на пользовательский поток не влияет.
+ */
+export function useCommentsNameSync() {
+  function syncCommentsName(): void {
+    void $fetch(COMMENTS_NAME_SYNC_API_PATH, { method: 'POST' }).catch(
+      () => {},
+    );
+  }
+
+  return { syncCommentsName };
+}

--- a/app/features/bug-report/modal/ui/BugReportAuthor.vue
+++ b/app/features/bug-report/modal/ui/BugReportAuthor.vue
@@ -5,7 +5,7 @@
 
   const authorName = computed(() =>
     isLoggedIn.value && user.value
-      ? user.value.username
+      ? user.value.displayName || user.value.username
       : BUG_REPORT_ANONYMOUS_USER,
   );
 

--- a/app/features/comments/composables/useCommentsSection.ts
+++ b/app/features/comments/composables/useCommentsSection.ts
@@ -241,6 +241,21 @@ export function useCommentsSection(
 ): UseCommentsSectionReturn {
   const toast = useToast();
   const { user } = useUser();
+  const { syncCommentsName } = useCommentsNameSync();
+
+  // Отображаемое имя автора (заменяет логин). Нужно, чтобы свежесозданный
+  // комментарий сразу показывал имя, а не логин из токена (сервис стамперит логин).
+  const selfDisplayName = computed(
+    () => user.value?.displayName || user.value?.username || '',
+  );
+
+  // Подменяет имя автора у только что созданного комментария на отображаемое —
+  // до того, как syncCommentsName пересчитает снимок на бэкенде.
+  function withSelfDisplayName(created: CommentEntry): CommentEntry {
+    return selfDisplayName.value
+      ? { ...created, authorName: selfDisplayName.value }
+      : created;
+  }
 
   const rootNodes = ref<Array<CommentNode>>([]);
 
@@ -578,9 +593,16 @@ export function useCommentsSection(
         content,
       });
 
-      rootNodes.value = [createCommentNode(created), ...rootNodes.value];
+      rootNodes.value = [
+        createCommentNode(withSelfDisplayName(created)),
+        ...rootNodes.value,
+      ];
+
       totalCount.value += 1;
       startCooldown(COMMENT_SUBMIT_COOLDOWN_SECONDS);
+
+      // Заменяем логин на отображаемое имя во всех комментариях автора (best-effort).
+      syncCommentsName();
 
       return true;
     } catch (error) {
@@ -620,7 +642,10 @@ export function useCommentsSection(
       totalCount.value += 1;
 
       if (node.repliesLoaded) {
-        node.replies = [...node.replies, createCommentNode(created)];
+        node.replies = [
+          ...node.replies,
+          createCommentNode(withSelfDisplayName(created)),
+        ];
 
         node.repliesExpanded = true;
       } else {
@@ -628,6 +653,9 @@ export function useCommentsSection(
       }
 
       startCooldown(COMMENT_SUBMIT_COOLDOWN_SECONDS);
+
+      // Заменяем логин на отображаемое имя во всех комментариях автора (best-effort).
+      syncCommentsName();
 
       return true;
     } catch (error) {

--- a/app/features/comments/section/CommentsSection.vue
+++ b/app/features/comments/section/CommentsSection.vue
@@ -351,6 +351,13 @@
 
 <template>
   <section class="flex flex-col gap-4">
+    <!--
+      Разделитель отбивает обсуждение от контента материала как отдельный
+      блок. Вынесен из ClientOnly, чтобы линия стояла всегда — и во время
+      загрузки ленты, и после.
+    -->
+    <USeparator />
+
     <ClientOnly>
       <header class="flex items-center gap-2">
         <h2 class="text-lg font-semibold text-highlighted">

--- a/app/features/initiative/workspace/ui/PlayerAddForm.vue
+++ b/app/features/initiative/workspace/ui/PlayerAddForm.vue
@@ -71,7 +71,7 @@
     <div class="flex flex-wrap items-end gap-2">
       <UFormField
         label="Имя игрока"
-        class="min-w-0 basis-full"
+        class="min-w-0 flex-1"
       >
         <UInput
           v-model="name"

--- a/app/features/initiative/workspace/ui/TrackerAddPanel.vue
+++ b/app/features/initiative/workspace/ui/TrackerAddPanel.vue
@@ -49,9 +49,10 @@
 
     <div
       v-if="open"
-      class="grid items-start gap-4 md:grid-cols-3"
+      class="grid items-start gap-4 md:grid-cols-5"
     >
       <PlayerAddForm
+        class="md:col-span-2"
         :count="playerCount"
         :disabled="!canAddPlayer"
         :loading="isMutating"
@@ -59,7 +60,7 @@
       />
 
       <CreatureAddForm
-        class="md:col-span-2"
+        class="md:col-span-3"
         :count="creatureCount"
         :disabled="!canAddCreature"
         :loading="isMutating"

--- a/app/features/profile/general/composables/index.ts
+++ b/app/features/profile/general/composables/index.ts
@@ -1,0 +1,1 @@
+export * from './useDisplayName';

--- a/app/features/profile/general/composables/useDisplayName.ts
+++ b/app/features/profile/general/composables/useDisplayName.ts
@@ -1,0 +1,66 @@
+import { FetchError } from 'ofetch';
+
+import {
+  DISPLAY_NAME_API_PATH,
+  DISPLAY_NAME_ERROR_TOAST_COLOR,
+  DISPLAY_NAME_ERROR_TOAST_DESCRIPTION,
+  DISPLAY_NAME_ERROR_TOAST_TITLE,
+  DISPLAY_NAME_SUCCESS_TOAST_COLOR,
+  DISPLAY_NAME_SUCCESS_TOAST_DESCRIPTION,
+  DISPLAY_NAME_SUCCESS_TOAST_TITLE,
+} from '../model';
+
+/**
+ * Смена отображаемого имени. После успеха перезапрашивает профиль (`useUser`),
+ * чтобы новое имя сразу подхватилось везде, где оно рендерится.
+ */
+export function useDisplayName() {
+  const toast = useToast();
+  const { fetch: refreshUser } = useUser();
+  const { syncCommentsName } = useCommentsNameSync();
+  const isLoading = ref(false);
+  const error = ref<string | null>(null);
+
+  async function changeDisplayName(displayName: string): Promise<boolean> {
+    isLoading.value = true;
+    error.value = null;
+
+    try {
+      await $fetch(DISPLAY_NAME_API_PATH, {
+        body: { displayName },
+        method: 'PATCH',
+      });
+
+      await refreshUser();
+
+      // Прокидываем новое имя в старые комментарии пользователя (best-effort).
+      syncCommentsName();
+
+      toast.add({
+        title: DISPLAY_NAME_SUCCESS_TOAST_TITLE,
+        description: DISPLAY_NAME_SUCCESS_TOAST_DESCRIPTION,
+        color: DISPLAY_NAME_SUCCESS_TOAST_COLOR,
+      });
+
+      return true;
+    } catch (changeError) {
+      error.value = DISPLAY_NAME_ERROR_TOAST_DESCRIPTION;
+
+      if (changeError instanceof FetchError) {
+        error.value = changeError.data?.message || changeError.message;
+      }
+
+      toast.add({
+        title: DISPLAY_NAME_ERROR_TOAST_TITLE,
+        description: error.value ?? DISPLAY_NAME_ERROR_TOAST_DESCRIPTION,
+        color: DISPLAY_NAME_ERROR_TOAST_COLOR,
+      });
+
+      return false;
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  return { changeDisplayName, isLoading, error };
+}

--- a/app/features/profile/general/model/consts.ts
+++ b/app/features/profile/general/model/consts.ts
@@ -2,3 +2,26 @@ export const ProfileCardUI = {
   header: 'px-6 py-4',
   body: 'p-6',
 } as const;
+
+export const DISPLAY_NAME_API_PATH = '/api/user/profile/display-name';
+
+export const PERSONAL_DATA_CARD_TITLE = 'Личные данные';
+
+export const DISPLAY_NAME_LABEL = 'Отображаемое имя';
+export const DISPLAY_NAME_DESCRIPTION = 'Показывается на сайте вместо логина';
+export const DISPLAY_NAME_PLACEHOLDER = 'Например, Отважный Странник';
+export const DISPLAY_NAME_SUBMIT_LABEL = 'Сохранить';
+
+export const LOGIN_LABEL = 'Логин';
+export const LOGIN_DESCRIPTION = 'Уникальный идентификатор, скрыт от других';
+export const EMAIL_LABEL = 'Email';
+export const EMAIL_DESCRIPTION = 'Адрес электронной почты';
+
+export const DISPLAY_NAME_SUCCESS_TOAST_TITLE = 'Имя обновлено';
+export const DISPLAY_NAME_SUCCESS_TOAST_DESCRIPTION =
+  'Теперь оно отображается на сайте вместо логина';
+export const DISPLAY_NAME_SUCCESS_TOAST_COLOR = 'success';
+
+export const DISPLAY_NAME_ERROR_TOAST_TITLE = 'Не удалось сменить имя';
+export const DISPLAY_NAME_ERROR_TOAST_DESCRIPTION = 'Попробуйте ещё раз';
+export const DISPLAY_NAME_ERROR_TOAST_COLOR = 'error';

--- a/app/features/profile/general/model/schemas.ts
+++ b/app/features/profile/general/model/schemas.ts
@@ -4,7 +4,7 @@ export const displayNameSchema = z.object({
   displayName: z
     .string()
     .min(2, 'Минимум 2 символа')
-    .max(50, 'Максимум 50 символов')
+    .max(24, 'Максимум 24 символа')
     .regex(
       /^[\w\p{L}\s-]+$/u,
       'Только буквы, цифры, пробелы, дефисы и подчёркивания',

--- a/app/features/profile/general/ui/PersonalDataCard.vue
+++ b/app/features/profile/general/ui/PersonalDataCard.vue
@@ -1,11 +1,60 @@
 <script setup lang="ts">
+  import type { FormSubmitEvent } from '#ui/types';
   import type { UserProfile } from '~/shared/types';
 
-  import { ProfileCardUI } from '../model';
+  import { useDisplayName } from '../composables';
+  import {
+    DISPLAY_NAME_DESCRIPTION,
+    DISPLAY_NAME_LABEL,
+    DISPLAY_NAME_PLACEHOLDER,
+    DISPLAY_NAME_SUBMIT_LABEL,
+    displayNameSchema,
+    EMAIL_DESCRIPTION,
+    EMAIL_LABEL,
+    LOGIN_DESCRIPTION,
+    LOGIN_LABEL,
+    PERSONAL_DATA_CARD_TITLE,
+    ProfileCardUI,
+  } from '../model';
 
-  defineProps<{
+  interface DisplayNameForm {
+    displayName: string;
+  }
+
+  const props = defineProps<{
     profile?: UserProfile;
   }>();
+
+  const { changeDisplayName, isLoading } = useDisplayName();
+
+  const displayNameForm = reactive<DisplayNameForm>({ displayName: '' });
+
+  // Текущее сохранённое имя: отображаемое, иначе логин (фолбэк «пусто → логин»).
+  const savedDisplayName = computed(
+    () => props.profile?.displayName || props.profile?.username || '',
+  );
+
+  // Синхронизируем поле с профилем при загрузке и после успешной смены:
+  // refreshUser обновляет profile → поле сбрасывается на сохранённое значение.
+  watch(
+    savedDisplayName,
+    (value) => {
+      displayNameForm.displayName = value;
+    },
+    { immediate: true },
+  );
+
+  const isUnchanged = computed(
+    () => displayNameForm.displayName.trim() === savedDisplayName.value,
+  );
+
+  const isSubmitDisabled = computed(
+    () => isLoading.value || isUnchanged.value || !props.profile,
+  );
+
+  async function handleSubmit(event: FormSubmitEvent<DisplayNameForm>) {
+    await changeDisplayName(event.data.displayName.trim());
+  }
 </script>
 
 <template>
@@ -18,71 +67,95 @@
           aria-hidden="true"
         />
 
-        <h3 class="font-semibold text-primary">Личные данные</h3>
+        <h3 class="font-semibold text-primary">
+          {{ PERSONAL_DATA_CARD_TITLE }}
+        </h3>
       </div>
     </template>
 
-    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-      <!-- Отображаемое имя (смена пока не реализована на бэкенде) -->
-      <UFormField
-        v-if="isDev"
-        label="Отображаемое имя"
-        description="Сменить имя пока нельзя, добавим позже"
-        class="sm:col-span-2"
+    <div class="space-y-4">
+      <!-- Отображаемое имя — единственное редактируемое поле -->
+      <UForm
+        :state="displayNameForm"
+        :schema="displayNameSchema"
+        @submit="handleSubmit"
       >
-        <USkeleton
-          v-if="!profile"
-          class="h-9 w-full"
-        />
+        <UFormField
+          :label="DISPLAY_NAME_LABEL"
+          :description="DISPLAY_NAME_DESCRIPTION"
+          name="displayName"
+        >
+          <USkeleton
+            v-if="!profile"
+            class="h-9 w-full"
+          />
 
-        <UInput
-          v-else
-          :model-value="profile.username"
-          disabled
-          icon="tabler:forms"
-          class="w-full"
-        />
-      </UFormField>
+          <div
+            v-else
+            class="flex items-start gap-2"
+          >
+            <UInput
+              v-model="displayNameForm.displayName"
+              :placeholder="DISPLAY_NAME_PLACEHOLDER"
+              :disabled="isLoading"
+              :maxlength="24"
+              icon="tabler:forms"
+              class="flex-1"
+            />
 
-      <!-- Логин -->
-      <UFormField
-        label="Логин"
-        description="Уникальный идентификатор"
-      >
-        <USkeleton
-          v-if="!profile"
-          class="h-9 w-full"
-        />
+            <UButton
+              type="submit"
+              color="primary"
+              :loading="isLoading"
+              :disabled="isSubmitDisabled"
+            >
+              {{ DISPLAY_NAME_SUBMIT_LABEL }}
+            </UButton>
+          </div>
+        </UFormField>
+      </UForm>
 
-        <UInput
-          v-else
-          :model-value="profile.username"
-          disabled
-          icon="tabler:fingerprint"
-          variant="outline"
-          color="neutral"
-          class="w-full"
-        />
-      </UFormField>
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <!-- Логин -->
+        <UFormField
+          :label="LOGIN_LABEL"
+          :description="LOGIN_DESCRIPTION"
+        >
+          <USkeleton
+            v-if="!profile"
+            class="h-9 w-full"
+          />
 
-      <!-- Email -->
-      <UFormField
-        label="Email"
-        description="Адрес электронной почты"
-      >
-        <USkeleton
-          v-if="!profile"
-          class="h-9 w-full"
-        />
+          <UInput
+            v-else
+            :model-value="profile.username"
+            disabled
+            icon="tabler:fingerprint"
+            variant="outline"
+            color="neutral"
+            class="w-full"
+          />
+        </UFormField>
 
-        <UInput
-          v-else
-          :model-value="profile.email"
-          disabled
-          icon="tabler:mail"
-          class="w-full"
-        />
-      </UFormField>
+        <!-- Email -->
+        <UFormField
+          :label="EMAIL_LABEL"
+          :description="EMAIL_DESCRIPTION"
+        >
+          <USkeleton
+            v-if="!profile"
+            class="h-9 w-full"
+          />
+
+          <UInput
+            v-else
+            :model-value="profile.email"
+            disabled
+            icon="tabler:mail"
+            class="w-full"
+          />
+        </UFormField>
+      </div>
     </div>
   </UCard>
 </template>

--- a/app/features/profile/sidebar/ui/ProfileAvatar.vue
+++ b/app/features/profile/sidebar/ui/ProfileAvatar.vue
@@ -4,11 +4,16 @@
   import { useMyRewards } from '~profile/activation/composables';
   import { AVATAR_FRAME_IMAGE_URL } from '~profile/activation/model';
 
-  defineProps<{
+  const props = defineProps<{
     profile?: UserProfile;
   }>();
 
   const { hasPerk } = useMyRewards();
+
+  // Инициалы аватара берём из отображаемого имени, иначе из логина.
+  const avatarAlt = computed(
+    () => props.profile?.displayName || props.profile?.username,
+  );
 
   // Рамка аватара — косметический перк AVATAR_FRAME, выданный кодом.
   const hasAvatarFrame = computed(() => hasPerk('AVATAR_FRAME'));
@@ -24,7 +29,7 @@
     />
 
     <UAvatar
-      :alt="profile?.username"
+      :alt="avatarAlt"
       size="3xl"
       class="relative z-10 h-32 w-32 text-4xl shadow-2xl ring-4 ring-default transition-transform duration-200 group-active:scale-95"
     />

--- a/app/features/profile/sidebar/ui/ProfileBadge.vue
+++ b/app/features/profile/sidebar/ui/ProfileBadge.vue
@@ -6,12 +6,18 @@
     useMySubscriptions,
   } from '~profile/activation/composables';
 
-  defineProps<{
+  const props = defineProps<{
     profile?: UserProfile;
   }>();
 
   const { subscriptions } = useMySubscriptions();
   const { hasPerk } = useMyRewards();
+
+  // Отображаемое имя вместо логина; фолбэки — логин, затем общий плейсхолдер.
+  const displayName = computed(
+    () =>
+      props.profile?.displayName || props.profile?.username || 'Путешественник',
+  );
 
   // Бейдж активной подписки — если есть хотя бы одна подписка в статусе ACTIVE.
   const isSubscriptionActive = computed(() =>
@@ -43,7 +49,7 @@
             : 'text-primary'
         "
       >
-        {{ profile?.username || 'Путешественник' }}
+        {{ displayName }}
       </h2>
     </div>
 

--- a/app/features/user/helmet/ui/UserInfo.vue
+++ b/app/features/user/helmet/ui/UserInfo.vue
@@ -3,13 +3,18 @@
 
   import { useProfileBadges } from '~profile/activation/composables';
 
-  defineProps<{
+  const props = defineProps<{
     user: UserProfile;
   }>();
 
   const emit = defineEmits<{
     'open-profile': [];
   }>();
+
+  // Отображаемое имя вместо логина; фолбэк — логин.
+  const displayName = computed(
+    () => props.user.displayName || props.user.username,
+  );
 
   // Данные бейджей прогреваются заранее в хелмете (см. UserHelmet), поэтому к
   // моменту открытия панели корона и рамка уже готовы — без «доезда».
@@ -28,7 +33,7 @@
       <div
         class="mb-1 overflow-hidden text-2xl font-semibold text-ellipsis whitespace-nowrap"
       >
-        {{ user.username }}
+        {{ displayName }}
       </div>
 
       <div class="flex flex-wrap items-center gap-1.5">
@@ -60,7 +65,7 @@
       @click.left.exact.prevent="openProfile"
     >
       <UAvatar
-        :alt="user.username"
+        :alt="displayName"
         size="3xl"
         :ui="{ fallback: 'uppercase' }"
       />

--- a/app/shared/types/user.ts
+++ b/app/shared/types/user.ts
@@ -11,5 +11,10 @@ export interface UserProfile {
   id: string | null;
   email: string;
   username: string;
+  /**
+   * Отображаемое имя — заменяет логин в UI (профиль, комментарии, рейтинги).
+   * Хранится в core-api; null, если core-api недоступен, — тогда показываем логин.
+   */
+  displayName: string | null;
   roles: string[];
 }

--- a/server/api/auth/me.get.ts
+++ b/server/api/auth/me.get.ts
@@ -8,17 +8,19 @@ export default defineEventHandler(async (event) => {
   const token = getTokenFromRequest(event);
   const tokenPayload = parseAuthJwtPayload(await verifyJwt(token));
 
-  const user = parseAuthUserResponse(
-    await fetchAuthService<unknown>('/api/auth/me', {
+  const [user, displayName] = await Promise.all([
+    fetchAuthService<unknown>('/api/auth/me', {
       headers: {
         authorization: `Bearer ${token}`,
       },
-    }),
-  );
+    }).then(parseAuthUserResponse),
+    fetchUserDisplayName(token),
+  ]);
 
   return {
     ...user,
     id: tokenPayload.sub ?? null,
     roles: tokenPayload.roles,
+    displayName,
   };
 });

--- a/server/api/user/comments/sync-name.post.ts
+++ b/server/api/user/comments/sync-name.post.ts
@@ -1,0 +1,30 @@
+import { parseAuthJwtPayload } from '#server/utils/authService';
+
+/**
+ * Приводит имя автора в комментариях к текущему отображаемому имени пользователя.
+ * Дёргается фронтом после смены имени и после публикации комментария (новый
+ * комментарий стамперит логин из токена — этот вызов заменяет его на имя).
+ *
+ * Всё best-effort: без `sub` в токене, без имени в core-api или без межсервисного
+ * токена просто возвращаем `synced: false`, не роняя запрос.
+ */
+export default defineEventHandler(async (event) => {
+  const token = getTokenFromRequest(event);
+  const tokenPayload = parseAuthJwtPayload(await verifyJwt(token));
+
+  const authorId = tokenPayload.sub;
+
+  if (!authorId) {
+    return { synced: false };
+  }
+
+  const displayName = await fetchUserDisplayName(token);
+
+  if (!displayName) {
+    return { synced: false };
+  }
+
+  const synced = await renameCommentsAuthor(authorId, displayName);
+
+  return { synced };
+});

--- a/server/utils/commentsRename.ts
+++ b/server/utils/commentsRename.ts
@@ -1,0 +1,44 @@
+/** Заголовок межсервисной авторизации internal API comments-service. */
+const COMMENTS_SERVICE_TOKEN_HEADER = 'X-Service-Token';
+
+/** Internal-эндпоинт массового переименования автора в comments-service. */
+const COMMENTS_RENAME_PATH = '/api/v1/internal/comments/rename-by-author';
+
+/**
+ * Best-effort: просит comments-service привести имя автора во ВСЕХ его комментариях
+ * к текущему отображаемому имени (по `authorId` = `sub` токена). Вызывается после
+ * смены имени и после публикации комментария.
+ *
+ * Ошибки и отсутствие межсервисного токена (`NITRO_COMMENTS_SERVICE_TOKEN`) не
+ * пробрасываются — синхронизация имени не должна ронять пользовательский поток.
+ * Возвращает `true`, если запрос ушёл успешно.
+ */
+export async function renameCommentsAuthor(
+  authorId: string,
+  displayName: string,
+): Promise<boolean> {
+  const { url, serviceToken } = getCommentsSecrets();
+
+  if (!serviceToken) {
+    return false;
+  }
+
+  try {
+    await $fetch(`${url}${COMMENTS_RENAME_PATH}`, {
+      body: { authorId, displayName },
+      headers: {
+        [COMMENTS_SERVICE_TOKEN_HEADER]: serviceToken,
+      },
+      method: 'POST',
+    });
+
+    return true;
+  } catch (error) {
+    consola.warn(
+      '[comments-rename] Не удалось обновить имя автора в комментариях:',
+      error,
+    );
+
+    return false;
+  }
+}

--- a/server/utils/displayName.ts
+++ b/server/utils/displayName.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+const displayNameResponseSchema = z.object({
+  displayName: z.string().min(1),
+});
+
+/**
+ * Тянет отображаемое имя текущего пользователя из core-api (владелец данных).
+ * Best-effort: недоступность core-api или ещё не задеплоенная ручка (404) → null,
+ * и вызывающий откатывается к логину. Побочно инициирует ленивое создание имени
+ * на стороне core-api при первом обращении.
+ */
+export async function fetchUserDisplayName(
+  token: string,
+): Promise<string | null> {
+  try {
+    const { url } = getApiSecrets();
+
+    const payload = await $fetch<unknown>(
+      `${url}/api/user/profile/display-name`,
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    const parsed = displayNameResponseSchema.safeParse(payload);
+
+    return parsed.success ? parsed.data.displayName : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Что и зачем

Пользователь может задать **отображаемое имя**, которое показывается на сайте
вместо логина. Логин становится приватным идентификатором (виден только
владельцу в профиле), а публично — в профиле, шапке, комментариях и
баг-репортах — используется отображаемое имя. Везде есть фолбэк на логин, если
имя не задано или недоступно.

Имя хранится в core-api (не в JWT). core-app выступает BFF-прослойкой:
проксирует смену имени и отдаёт `displayName` вместе с профилем в `/api/auth/me`.

## Фронтенд

- **Карточка личных данных** — новое редактируемое поле «Отображаемое имя»
  (`UForm` + zod-схема, 2–24 символа); логин и email оставлены только для чтения.
- **`useDisplayName`** — PATCH-смена имени, `refreshUser` после успеха и
  best-effort синхронизация имени в старых комментариях, тосты успеха/ошибки.
- **`useCommentsNameSync`** (глобальный composable) — fire-and-forget POST
  синхронизации имени автора в комментариях.
- **`useCommentsSection`** — свежесозданный комментарий сразу показывает
  отображаемое имя, а не логин из токена.
- Отображаемое имя заменяет логин в **бейдже профиля, alt аватара, шапке
  пользователя и авторе баг-репорта** (везде с фолбэком на логин).
- `UserProfile` дополнен полем `displayName: string | null`.
- Тексты, лейблы, тосты, API-путь и схема вынесены в `model`.

## Бэкенд (BFF)

- `server/api/user/profile/display-name` — проксирование смены имени в core-api.
- `server/api/user/comments/sync-name` — синхронизация имени автора в
  комментариях.
- `server/api/auth/me` — отдаёт `displayName` вместе с профилем.
- Утилиты `server/utils/displayName.ts` и `server/utils/commentsRename.ts`.

## Попутные изменения

- **initiative:** компактная панель добавления участников — имя, КД, бонус и
  кнопка в одну строку; сетка панели перестроена на `md:grid-cols-5`
  («Игрок» — 2 колонки, «Существа» — 3).
- **comments:** `USeparator` над заголовком блока комментариев — визуально
  отбивает обсуждение от контента материала; виден и во время загрузки ленты.

## Проверка

- `eslint` и `vue-tsc` проходят чисто (в т.ч. через pre-commit хук).
- Требует ручного QA в браузере: смена имени → тост → обновление имени в
  профиле/шапке/комментариях без перезагрузки; фолбэк на логин при пустом имени.

## На заметку

Лимит длины имени `24` пока продублирован числом в схеме и в шаблоне
(`:maxlength`) — по правилам проекта стоит вынести в `DISPLAY_NAME_MAX_LENGTH`.
Некритично, можно поправить отдельным коммитом.
