### PR TITLE
fix(bestiary): корректный расчёт пассивной внимательности при редакти…

### DIFF
--- a/app/features/bestiary/editor/CreatureEditor.vue
+++ b/app/features/bestiary/editor/CreatureEditor.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-  import type { CreatureCreate } from '~bestiary/model';
+  import type { CreateExperience, CreatureCreate } from '~bestiary/model';
 
+  import { DictionaryService } from '~/shared/api';
   import { getInitialState } from '~bestiary/model';
   import { CreaturePreview } from '~bestiary/preview';
   import { EditorBaseInfo } from '~ui/editor';
@@ -35,10 +36,37 @@
     CreatureType,
   } from './ui';
 
+  const { data: challengeRatings } = await useAsyncData(
+    'dictionaries-challenge-rating',
+    () => DictionaryService.challengeRating(),
+    { dedupe: 'defer' },
+  );
+
+  /**
+   * Восстанавливает бонус мастерства по показателю опасности.
+   *
+   * `/raw` его не возвращает — на бэкенде он выводится из ПО. Без этого форма
+   * редактирования всегда стартовала с БМ +2 и пересчитывала зависимые поля
+   * (пассивная внимательность, модификаторы навыков, инициатива) неверно для
+   * всех существ с ПО 5 и выше.
+   */
+  function normalizeLoaded(
+    raw: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const experience = raw.experience as CreateExperience | undefined;
+
+    const option = challengeRatings.value?.find(
+      (item) => item.value === experience?.value,
+    );
+
+    return option ? { ...raw, proficiencyBonus: option.pb } : raw;
+  }
+
   const { state, submitState, onError, onSubmit, revisionControl } =
     useWorkshopForm<CreatureCreate>({
       actionUrl: '/api/v2/bestiary',
       getInitialState,
+      normalizeLoaded,
       revisionEntityType: REVISION_ENTITY_TYPES.CREATURE,
     });
 </script>

--- a/app/features/bestiary/editor/ui/CreatureSenses.vue
+++ b/app/features/bestiary/editor/ui/CreatureSenses.vue
@@ -18,12 +18,18 @@
 
     const perception = skills.find((skill) => skill.skill === 'PERCEPTION');
 
-    if (perception) {
-      model.value.passivePerception =
-        10 + wisdomMod + perception.multiplier * proficiencyBonus;
-    } else {
+    if (!perception) {
       model.value.passivePerception = 10 + wisdomMod;
+
+      return;
     }
+
+    // `bonus` у загруженных записей приходит как `null`, поэтому `?? 0`.
+    model.value.passivePerception =
+      10
+      + wisdomMod
+      + perception.multiplier * proficiencyBonus
+      + (perception.bonus ?? 0);
   });
 </script>
 


### PR DESCRIPTION
…ровании

`/raw` не возвращает `proficiencyBonus`, а `SelectChallengeRating` выставлял его только при ручном выборе ПО. Из-за этого форма редактирования всегда стартовала с БМ +2 и пересчитывала пассивную внимательность (а также модификаторы навыков и инициативу) неверно для всех существ с ПО 5 и выше — например, у древнего белого дракона вместо 23 получалось 15.

Теперь БМ восстанавливается из словаря ПО в `normalizeLoaded`, чтобы значение попадало и в `previousState` и форма не считалась изменённой сразу при открытии.

Дополнительно формула пассивной внимательности учитывает `bonus` навыка (с `?? 0` — у загруженных записей он приходит как `null`), поэтому правка поля «Бонус» теперь вообще запускает пересчёт.