### PR TITLE
Добавить врождённые заклинания видов в лист персонажа

### DIFF
--- a/app/features/character-sheet/body/CharacterSheetBody.vue
+++ b/app/features/character-sheet/body/CharacterSheetBody.vue
@@ -21,6 +21,7 @@
   import {
     ABILITY_LABELS,
     ARMOR_PROFICIENCY_GROUPS,
+    getAvailableInnateSpells,
     getWeaponAttackBonus,
     getWeaponDamage,
     LANGUAGE_PROFICIENCY_GROUPS,
@@ -595,6 +596,10 @@
     speciesWizardModal.open();
   }
 
+  const availableInnateSpells = computed(() =>
+    getAvailableInnateSpells(character.value),
+  );
+
   function handleClassEdit() {
     if (!ensureEditable()) {
       return;
@@ -961,6 +966,7 @@
           :carrying-capacity="carryingCapacity"
           :features="character.features"
           :spells="character.spells"
+          :innate-spells="availableInnateSpells"
           :spellcasting="spellcastingBreakdown"
           :spell-slots="spellSlotRows"
           :has-main-tab="!isWide"

--- a/app/features/character-sheet/body/ui/SheetInventoryTabs.vue
+++ b/app/features/character-sheet/body/ui/SheetInventoryTabs.vue
@@ -41,6 +41,7 @@
     carryingCapacity: number;
     features: CharacterFeature[];
     spells: CharacterSpell[];
+    innateSpells: CharacterSpell[];
     spellcasting: SpellcastingBreakdown;
 
     /** Ячейки заклинаний по кругам; пусто — класс ячеек не даёт. */
@@ -821,6 +822,7 @@
           <SheetSpellsTab
             v-else-if="activeSlot === 'spells'"
             :spells="spells"
+            :innate-spells="innateSpells"
             :spellcasting="spellcasting"
             :spell-slots="spellSlots"
             @add-spell="handleSpellAdd"

--- a/app/features/character-sheet/body/ui/SheetSpeciesWizardModal.vue
+++ b/app/features/character-sheet/body/ui/SheetSpeciesWizardModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
   import type {
+    CharacterInnateSpell,
     ClassChoice,
     FeatureDescriptionNode,
     SpeciesOption,
@@ -33,6 +34,27 @@
   import SheetSearchInput from './SheetSearchInput.vue';
 
   type WizardStep = 'species' | 'features';
+
+  /** Объединяет заклинания вида и происхождения, сохраняя самый ранний уровень открытия. */
+  function mergeInnateSpells(
+    speciesSpells: CharacterInnateSpell[],
+    lineageSpells: CharacterInnateSpell[],
+  ): CharacterInnateSpell[] {
+    const spellsByUrl = new Map<string, CharacterInnateSpell>();
+
+    for (const innateSpell of [...speciesSpells, ...lineageSpells]) {
+      const existingSpell = spellsByUrl.get(innateSpell.spell.url);
+
+      if (
+        !existingSpell
+        || innateSpell.requiredLevel < existingSpell.requiredLevel
+      ) {
+        spellsByUrl.set(innateSpell.spell.url, innateSpell);
+      }
+    }
+
+    return [...spellsByUrl.values()];
+  }
 
   const emit = defineEmits<{
     close: [];
@@ -458,6 +480,10 @@
         name: detail.name,
         lineageUrl: lineage?.url ?? null,
         lineageName: lineage?.name ?? null,
+        innateSpells: mergeInnateSpells(
+          detail.innateSpells,
+          lineage?.innateSpells ?? [],
+        ),
       },
       size: sizeChoice.value ?? null,
       speed: parseSpeedFromText(effectiveSpeedText.value),

--- a/app/features/character-sheet/body/ui/SheetSpellsTab.vue
+++ b/app/features/character-sheet/body/ui/SheetSpellsTab.vue
@@ -18,13 +18,17 @@
     getSpellSlotCircles,
     getSpellSlotSummary,
     getSpellStatRows,
+    INNATE_SPELL_GROUP_LABEL,
+    INNATE_SPELL_GROUP_LEVEL,
     isCustomSpell,
     SHEET_TAB_EMPTY_LABELS,
+    SPELL_NAME_SORT_LOCALE,
     SPELL_SLOTS_LABEL,
   } from '../../model';
 
   const props = defineProps<{
     spells: CharacterSpell[];
+    innateSpells: CharacterSpell[];
     spellcasting: SpellcastingBreakdown;
 
     /** Ячейки заклинаний по кругам; пусто — класс ячеек не даёт. */
@@ -86,12 +90,35 @@
     () => new Map(props.spellSlots.map((row) => [row.level, row])),
   );
 
-  const displayGroups = computed(() =>
-    getSpellGroups(
+  const displayGroups = computed(() => {
+    const regularGroups = getSpellGroups(
       props.spells,
       props.spellSlots.map((row) => row.level),
-    ).map((group) => {
-      const slotRow = slotRowByLevel.value.get(group.level);
+    ).map((group) => ({ ...group, innate: false }));
+
+    const groups = props.innateSpells.length
+      ? [
+          {
+            level: INNATE_SPELL_GROUP_LEVEL,
+            label: INNATE_SPELL_GROUP_LABEL,
+            spells: [...props.innateSpells].sort(
+              (firstSpell, secondSpell) =>
+                firstSpell.level - secondSpell.level
+                || firstSpell.name.localeCompare(
+                  secondSpell.name,
+                  SPELL_NAME_SORT_LOCALE,
+                ),
+            ),
+            innate: true,
+          },
+          ...regularGroups,
+        ]
+      : regularGroups;
+
+    return groups.map((group) => {
+      const slotRow = group.innate
+        ? undefined
+        : slotRowByLevel.value.get(group.level);
 
       return {
         ...group,
@@ -113,20 +140,23 @@
 
           return {
             ...spell,
+            isInnate: group.innate,
             isCustom,
             isExpanded,
             // Действия строки — те же, что и у предмета снаряжения: своё
             // заклинание правится формой листа, каталожное сначала копируется в
             // лист, а убирается из книги и то, и другое.
-            menuItems: getSpellMenuItems({
-              onEdit: isCustom
-                ? () => emit('edit-spell', spell.url)
-                : undefined,
-              onCopy: isCustom
-                ? undefined
-                : () => emit('copy-spell', spell.url),
-              onRemove: () => emit('remove-spell', spell.url),
-            }),
+            menuItems: group.innate
+              ? []
+              : getSpellMenuItems({
+                  onEdit: isCustom
+                    ? () => emit('edit-spell', spell.url)
+                    : undefined,
+                  onCopy: isCustom
+                    ? undefined
+                    : () => emit('copy-spell', spell.url),
+                  onRemove: () => emit('remove-spell', spell.url),
+                }),
             // У каталожных заклинаний этих полей нет — список выйдет пустым.
             statRows: getSpellStatRows(spell),
             descriptionNodes: spell.description ?? [],
@@ -140,8 +170,8 @@
           };
         }),
       };
-    }),
-  );
+    });
+  });
 
   type DisplaySpell = (typeof displayGroups.value)[number]['spells'][number];
 
@@ -345,6 +375,7 @@
             <!-- Меню действий над заклинанием: тот же трейлинг, что и у строки
               снаряжения — правка своего, копия каталожного в лист и удаление -->
             <UDropdownMenu
+              v-if="!spell.isInnate"
               :items="spell.menuItems"
               :content="{ align: 'end' }"
             >
@@ -407,7 +438,7 @@
     <!-- Ряды ячеек показываются и без заклинаний (ими повышают круг уже
       известных), поэтому подсказка о пустой книге зависит от самих заклинаний -->
     <div
-      v-if="!spells.length"
+      v-if="!spells.length && !innateSpells.length"
       class="flex h-64 items-center justify-center rounded-lg border border-dashed border-default text-sm text-dimmed"
     >
       {{ SHEET_TAB_EMPTY_LABELS.spells }}

--- a/app/features/character-sheet/composables/useCharacterSheet.ts
+++ b/app/features/character-sheet/composables/useCharacterSheet.ts
@@ -843,7 +843,13 @@ export function useCharacterSheet() {
 
     character.value = {
       ...character.value,
-      species: { ...payload.species },
+      species: {
+        ...payload.species,
+        innateSpells: payload.species.innateSpells.map((innateSpell) => ({
+          ...innateSpell,
+          spell: { ...innateSpell.spell },
+        })),
+      },
       size: payload.size,
       speed: {
         ...payload.speed,

--- a/app/features/character-sheet/model/character-schema.ts
+++ b/app/features/character-sheet/model/character-schema.ts
@@ -56,16 +56,6 @@ const descriptionNodeSchema = z.custom<FeatureDescriptionNode>(
  */
 export const descriptionNodesSchema = z.array(descriptionNodeSchema).catch([]);
 
-const speciesSchema = z
-  .object({
-    url: z.string(),
-    name: z.string().catch(''),
-    lineageUrl: z.string().nullable().catch(null),
-    lineageName: z.string().nullable().catch(null),
-  })
-  .nullable()
-  .catch(null);
-
 const characterClassSchema = z
   .object({
     url: z.string(),
@@ -117,6 +107,24 @@ const spellSchema = z.object({
   duration: z.string().optional().catch(undefined),
   description: z.array(descriptionNodeSchema).optional().catch(undefined),
 });
+
+const speciesSchema = z
+  .object({
+    url: z.string(),
+    name: z.string().catch(''),
+    lineageUrl: z.string().nullable().catch(null),
+    lineageName: z.string().nullable().catch(null),
+    innateSpells: z
+      .array(
+        z.object({
+          spell: spellSchema,
+          requiredLevel: z.coerce.number().min(1).max(20).catch(1),
+        }),
+      )
+      .catch([]),
+  })
+  .nullable()
+  .catch(null);
 
 // Потраченные ячейки круга. Максимум считается по классу и уровню, поэтому в
 // документе его нет: круг с битым номером просто отбрасывается схемой массива.

--- a/app/features/character-sheet/model/constants.ts
+++ b/app/features/character-sheet/model/constants.ts
@@ -1123,6 +1123,15 @@ export const SPELLS_SEARCH_PATH = '/api/v2/spells/search';
 /** Базовый путь детали заклинания (`/{url}` — слаг из каталога). */
 export const SPELLS_DETAIL_BASE_PATH = '/api/v2/spells';
 
+/** Подпись отдельной группы заклинаний, полученных от вида и происхождения. */
+export const INNATE_SPELL_GROUP_LABEL = 'Врождённые';
+
+/** Служебный ключ группы врождённых заклинаний, не пересекающийся с кругами 0–9. */
+export const INNATE_SPELL_GROUP_LEVEL = -1;
+
+/** Локаль сортировки русских названий заклинаний. */
+export const SPELL_NAME_SORT_LOCALE = 'ru';
+
 /** Эндпоинт фильтров заклинаний — источник списка классов для чипов. */
 export const SPELLS_FILTERS_PATH = '/api/v2/spells/filters';
 

--- a/app/features/character-sheet/model/pdf/catalog.ts
+++ b/app/features/character-sheet/model/pdf/catalog.ts
@@ -11,6 +11,7 @@ import { chunk } from 'es-toolkit';
 import { SPELLS_DETAIL_BASE_PATH } from '../constants';
 import { parseCatalogDescription, parseCatalogSpellDetail } from '../schemas';
 import {
+  getAvailableInnateSpells,
   getInventoryItemDetailPath,
   isCustomInventoryItem,
   isCustomSpell,
@@ -117,7 +118,12 @@ function getPendingItems(
 export async function loadCatalogDescriptions(
   character: Character,
 ): Promise<CatalogDescriptions> {
-  const pendingSpellUrls = getPendingSpellUrls(character.spells);
+  const allSpells = [
+    ...character.spells,
+    ...getAvailableInnateSpells(character),
+  ];
+
+  const pendingSpellUrls = getPendingSpellUrls(allSpells);
   const pendingItems = getPendingItems(character.inventory);
 
   await Promise.all([
@@ -140,7 +146,7 @@ export async function loadCatalogDescriptions(
 
   const spells = new Map<string, CatalogSpellDetail>();
 
-  for (const spell of character.spells) {
+  for (const spell of allSpells) {
     const detail = spellDetailCache.get(spell.url);
 
     if (detail) {

--- a/app/features/character-sheet/model/pdf/page-reference.ts
+++ b/app/features/character-sheet/model/pdf/page-reference.ts
@@ -10,6 +10,7 @@ import type { PdfBuildContext, PdfFlow } from './types';
 
 import { FEATURE_ORIGIN_LABELS } from '../constants';
 import {
+  getAvailableInnateSpells,
   getInventoryGroups,
   getSpellGroups,
   getSpellLevelLabel,
@@ -137,7 +138,15 @@ function getReferenceEntries(
       description: feature.description,
     }));
 
-  const spells = getSpellGroups(character.spells, [])
+  const uniqueSpells = [
+    ...new Map(
+      [...getAvailableInnateSpells(character), ...character.spells].map(
+        (spell) => [spell.url, spell],
+      ),
+    ).values(),
+  ];
+
+  const spells = getSpellGroups(uniqueSpells, [])
     .flatMap((group) => group.spells)
     .map((spell) => getSpellEntry(spell, descriptions.spells.get(spell.url)))
     .filter((entry): entry is ReferenceEntry => entry !== null);

--- a/app/features/character-sheet/model/pdf/page-spells.ts
+++ b/app/features/character-sheet/model/pdf/page-spells.ts
@@ -1,8 +1,13 @@
 import type { Character, CharacterSpell } from '../types';
 import type { PdfBuildContext, PdfFlow, PdfTableColumn } from './types';
 
-import { RESOURCE_RECOVERY_LABELS } from '../constants';
 import {
+  INNATE_SPELL_GROUP_LABEL,
+  INNATE_SPELL_GROUP_LEVEL,
+  RESOURCE_RECOVERY_LABELS,
+} from '../constants';
+import {
+  getAvailableInnateSpells,
   getSpellGroups,
   getSpellLevelLabel,
   getSpellSlotCircles,
@@ -146,8 +151,9 @@ export function drawSpellsPage(
   character: Character,
 ): void {
   const slotRows = getSpellSlotRows(character);
+  const innateSpells = getAvailableInnateSpells(character);
 
-  if (!character.spells.length && !slotRows.length) {
+  if (!character.spells.length && !innateSpells.length && !slotRows.length) {
     return;
   }
 
@@ -159,7 +165,7 @@ export function drawSpellsPage(
 
   drawSpellSlots(context, character, flow);
 
-  if (!character.spells.length) {
+  if (!character.spells.length && !innateSpells.length) {
     return;
   }
 
@@ -169,10 +175,21 @@ export function drawSpellsPage(
 
   drawTableHead(context, flow, columns);
 
-  const groups = getSpellGroups(
-    character.spells,
-    slotRows.map((row) => row.level),
-  );
+  const groups = [
+    ...(innateSpells.length
+      ? [
+          {
+            level: INNATE_SPELL_GROUP_LEVEL,
+            label: INNATE_SPELL_GROUP_LABEL,
+            spells: innateSpells,
+          },
+        ]
+      : []),
+    ...getSpellGroups(
+      character.spells,
+      slotRows.map((row) => row.level),
+    ),
+  ];
 
   for (const group of groups) {
     if (!group.spells.length) {

--- a/app/features/character-sheet/model/schemas.ts
+++ b/app/features/character-sheet/model/schemas.ts
@@ -5,6 +5,7 @@ import type {
   BackgroundOption,
   BackgroundSummary,
   CatalogSpellDetail,
+  CharacterInnateSpell,
   ClassChoice,
   ClassFeatureSummary,
   ClassOption,
@@ -68,6 +69,18 @@ const speciesFeatureSchema = z.object({
   description: descriptionNodesSchema,
 });
 
+const speciesInnateSpellSchema = z.object({
+  spell: z.object({
+    url: z.string(),
+    name: z.object({ rus: z.string().catch('') }),
+    level: z.coerce.number().catch(0),
+    school: z.string().catch(''),
+    concentration: z.boolean().catch(false),
+    ritual: z.boolean().catch(false),
+  }),
+  requiredLevel: z.coerce.number().min(1).max(20).catch(1),
+});
+
 /** Схема детального ответа вида или подвида (нужные листу поля). */
 const speciesDetailSchema = z.object({
   url: z.string(),
@@ -80,6 +93,7 @@ const speciesDetailSchema = z.object({
     })
     .catch({ size: '', speed: '' }),
   features: z.array(speciesFeatureSchema).catch([]),
+  innateSpells: z.array(speciesInnateSpellSchema).catch([]),
 });
 
 /** Ответ списка подвидов: массив детальных ответов. */
@@ -100,6 +114,20 @@ function toSpeciesSummary(
     description: feature.description,
   }));
 
+  const innateSpells: CharacterInnateSpell[] = detail.innateSpells.map(
+    (innateSpell) => ({
+      spell: {
+        url: innateSpell.spell.url,
+        name: innateSpell.spell.name.rus,
+        level: innateSpell.spell.level,
+        school: innateSpell.spell.school,
+        concentration: innateSpell.spell.concentration,
+        ritual: innateSpell.spell.ritual,
+      },
+      requiredLevel: innateSpell.requiredLevel,
+    }),
+  );
+
   return {
     url: detail.url,
     name: detail.name.rus,
@@ -107,6 +135,7 @@ function toSpeciesSummary(
     sizeText: detail.properties.size,
     speedText: detail.properties.speed,
     features,
+    innateSpells,
   };
 }
 

--- a/app/features/character-sheet/model/types.ts
+++ b/app/features/character-sheet/model/types.ts
@@ -365,6 +365,15 @@ export interface CharacterSpecies {
 
   /** Название подвида; null — у вида нет подвидов. */
   lineageName: string | null;
+
+  /** Заклинания вида и происхождения с уровнем, на котором они открываются. */
+  innateSpells: CharacterInnateSpell[];
+}
+
+/** Врождённое заклинание и минимальный уровень персонажа для его получения. */
+export interface CharacterInnateSpell {
+  spell: CharacterSpell;
+  requiredLevel: number;
 }
 
 /** Выбранный класс персонажа. */
@@ -675,6 +684,8 @@ export interface SpeciesSummary {
   speedText: string;
 
   features: SpeciesFeatureSummary[];
+
+  innateSpells: CharacterInnateSpell[];
 }
 
 /** Опция класса в списке визарда (аналог `SpeciesOption`). */

--- a/app/features/character-sheet/model/utils.ts
+++ b/app/features/character-sheet/model/utils.ts
@@ -1618,6 +1618,20 @@ export function getSpellGroups(
 }
 
 /**
+ * Возвращает врождённые заклинания, уже открытые на текущем уровне персонажа.
+ *
+ * @param character персонаж листа.
+ * @returns доступные врождённые заклинания вида и происхождения.
+ */
+export function getAvailableInnateSpells(
+  character: Character,
+): CharacterSpell[] {
+  return (character.species?.innateSpells ?? [])
+    .filter((innateSpell) => innateSpell.requiredLevel <= character.level)
+    .map((innateSpell) => innateSpell.spell);
+}
+
+/**
  * Своё ли это заклинание: добавлено формой листа, а не выбрано из каталога.
  * У своих заклинаний нет страницы в разделе «Заклинания», поэтому описание они
  * хранят прямо в листе.

--- a/app/features/species/editor/SpeciesEditor.vue
+++ b/app/features/species/editor/SpeciesEditor.vue
@@ -10,7 +10,12 @@
   import { REVISION_ENTITY_TYPES } from '~workshop/revision/model';
   import { WorkshopEditorFormControls } from '~workshop/revision/ui';
 
-  import { SpeciesFeatures, SpeciesSizes, SpeciesSpeed } from './ui';
+  import {
+    SpeciesFeatures,
+    SpeciesInnateSpells,
+    SpeciesSizes,
+    SpeciesSpeed,
+  } from './ui';
 
   function getInitialState(): SpeciesCreate {
     return {
@@ -42,6 +47,7 @@
         },
       },
       features: [],
+      innateSpells: [],
       tags: [],
     };
   }
@@ -113,6 +119,8 @@
         <SpeciesSpeed v-model="state.properties.speed" />
 
         <SpeciesFeatures v-model="state.features" />
+
+        <SpeciesInnateSpells v-model="state.innateSpells" />
       </div>
     </UCard>
 

--- a/app/features/species/editor/ui/SpeciesInnateSpells.vue
+++ b/app/features/species/editor/ui/SpeciesInnateSpells.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+  import type { SpeciesCreate } from '~species/model';
+
+  import { SPECIES_INNATE_SPELL_EDITOR } from '~species/model';
+  import { EditorArrayControls } from '~ui/editor';
+  import { SelectSpell } from '~ui/select';
+
+  type InnateSpells = SpeciesCreate['innateSpells'];
+
+  const innateSpells = defineModel<InnateSpells>({ default: () => [] });
+
+  const selectedSpellUrls = computed(() =>
+    innateSpells.value.map((innateSpell) => innateSpell.spell).filter(Boolean),
+  );
+
+  /** Создаёт пустую строку врождённого заклинания первого уровня. */
+  function getEmptyInnateSpell(): InnateSpells[number] {
+    return {
+      spell: '',
+      requiredLevel: SPECIES_INNATE_SPELL_EDITOR.defaultCharacterLevel,
+    };
+  }
+
+  /** Добавляет новую строку выбора врождённого заклинания. */
+  function addInnateSpell(): void {
+    innateSpells.value = [...innateSpells.value, getEmptyInnateSpell()];
+  }
+
+  /** Возвращает уже выбранные URL, кроме значения редактируемой строки. */
+  function getExcludedSpellUrls(currentSpellUrl: string): string[] {
+    return selectedSpellUrls.value.filter(
+      (spellUrl) => spellUrl !== currentSpellUrl,
+    );
+  }
+</script>
+
+<template>
+  <USeparator class="col-span-full">
+    <span class="font-bold text-secondary">
+      {{ SPECIES_INNATE_SPELL_EDITOR.title }}
+    </span>
+  </USeparator>
+
+  <p class="col-span-full text-sm text-muted">
+    {{ SPECIES_INNATE_SPELL_EDITOR.description }}
+  </p>
+
+  <div
+    v-for="(innateSpell, spellIndex) in innateSpells"
+    :key="spellIndex"
+    class="col-span-full grid grid-cols-1 gap-4 md:grid-cols-24"
+  >
+    <UFormField
+      class="col-span-full md:col-span-15"
+      :label="SPECIES_INNATE_SPELL_EDITOR.spellLabel"
+      :name="`innateSpells.${spellIndex}.spell`"
+      required
+    >
+      <SelectSpell
+        v-model="innateSpell.spell"
+        :exclude-urls="getExcludedSpellUrls(innateSpell.spell)"
+      />
+    </UFormField>
+
+    <UFormField
+      class="col-span-full md:col-span-5"
+      :label="SPECIES_INNATE_SPELL_EDITOR.characterLevelLabel"
+      :name="`innateSpells.${spellIndex}.requiredLevel`"
+      required
+    >
+      <UInputNumber
+        v-model="innateSpell.requiredLevel"
+        :min="SPECIES_INNATE_SPELL_EDITOR.minimumCharacterLevel"
+        :max="SPECIES_INNATE_SPELL_EDITOR.maximumCharacterLevel"
+      />
+    </UFormField>
+
+    <EditorArrayControls
+      v-model="innateSpells"
+      :item="innateSpell"
+      :empty-object="getEmptyInnateSpell()"
+      :index="spellIndex"
+      cols="4"
+      only-remove
+    />
+  </div>
+
+  <div class="col-span-full flex justify-center">
+    <UButton
+      icon="tabler:plus"
+      color="neutral"
+      variant="soft"
+      @click.left.exact.prevent="addInnateSpell"
+    >
+      {{ SPECIES_INNATE_SPELL_EDITOR.addLabel }}
+    </UButton>
+  </div>
+</template>

--- a/app/features/species/editor/ui/index.ts
+++ b/app/features/species/editor/ui/index.ts
@@ -1,3 +1,4 @@
 export { default as SpeciesFeatures } from './SpeciesFeatures.vue';
+export { default as SpeciesInnateSpells } from './SpeciesInnateSpells.vue';
 export { default as SpeciesSizes } from './SpeciesSizes.vue';
 export { default as SpeciesSpeed } from './SpeciesSpeed.vue';

--- a/app/features/species/model/constants.ts
+++ b/app/features/species/model/constants.ts
@@ -1,0 +1,11 @@
+export const SPECIES_INNATE_SPELL_EDITOR = {
+  title: 'Врождённые заклинания',
+  description:
+    'Эти заговоры и заклинания всегда доступны персонажу. Уровень определяет, когда заклинание появится в листе.',
+  spellLabel: 'Заклинание',
+  characterLevelLabel: 'Уровень персонажа',
+  addLabel: 'Добавить заклинание',
+  minimumCharacterLevel: 1,
+  maximumCharacterLevel: 20,
+  defaultCharacterLevel: 1,
+};

--- a/app/features/species/model/index.ts
+++ b/app/features/species/model/index.ts
@@ -1,1 +1,2 @@
+export * from './constants';
 export * from './types';

--- a/app/features/species/model/types.ts
+++ b/app/features/species/model/types.ts
@@ -64,6 +64,10 @@ export interface SpeciesCreate extends EditorBaseInfoState {
     };
     description: string;
   }>;
+  innateSpells: Array<{
+    spell: string;
+    requiredLevel: number;
+  }>;
 }
 
 export interface SpeciesCreateSpeed {

--- a/app/shared/ui/select/SelectSpell.vue
+++ b/app/shared/ui/select/SelectSpell.vue
@@ -1,0 +1,198 @@
+<script setup lang="ts">
+  import { z } from '~/utils/zod';
+
+  import {
+    getSpellSelectLevelLabel,
+    SPELL_SELECT_CONFIG,
+  } from './spell-constants';
+
+  interface SpellSelectItem {
+    label: string;
+    value: string;
+    description: string;
+    level: number;
+  }
+
+  const props = withDefaults(
+    defineProps<{
+      disabled?: boolean;
+      excludeUrls?: string[];
+    }>(),
+    {
+      disabled: false,
+      excludeUrls: () => [],
+    },
+  );
+
+  const selectedSpellUrl = defineModel<string>({ default: '' });
+
+  const spellSchema = z.object({
+    url: z.string(),
+    name: z.object({
+      rus: z.string().catch(''),
+      eng: z.string().catch(''),
+    }),
+    level: z.coerce.number().catch(0),
+    school: z.string().catch(''),
+  });
+
+  const spellSearchSchema = z
+    .union([z.array(spellSchema), z.object({ value: z.array(spellSchema) })])
+    .catch([]);
+
+  const searchTerm = ref('');
+
+  const debouncedSearchTerm = refDebounced(
+    searchTerm,
+    SPELL_SELECT_CONFIG.searchDebounceMilliseconds,
+  );
+
+  const searchSpellItems = ref<SpellSelectItem[]>([]);
+  const selectedSpellItem = ref<SpellSelectItem | null>(null);
+  const isLoading = ref(false);
+
+  let requestGeneration = 0;
+
+  /** Преобразует проверенный ответ API в опцию выбора заклинания. */
+  function toSpellSelectItem(
+    spell: z.infer<typeof spellSchema>,
+  ): SpellSelectItem {
+    return {
+      label: spell.name.rus,
+      value: spell.url,
+      description: spell.name.eng || spell.school,
+      level: spell.level,
+    };
+  }
+
+  const spellItems = computed(() => {
+    const excludedUrls = new Set(props.excludeUrls);
+
+    const visibleSpellItems = searchSpellItems.value.filter(
+      (spell) =>
+        !excludedUrls.has(spell.value)
+        || spell.value === selectedSpellUrl.value,
+    );
+
+    if (
+      selectedSpellItem.value
+      && !visibleSpellItems.some(
+        (spell) => spell.value === selectedSpellItem.value?.value,
+      )
+    ) {
+      return [selectedSpellItem.value, ...visibleSpellItems];
+    }
+
+    return visibleSpellItems;
+  });
+
+  /** Загружает первую страницу заклинаний для текущей поисковой строки. */
+  async function loadSearchItems(): Promise<void> {
+    const generation = ++requestGeneration;
+
+    isLoading.value = true;
+
+    try {
+      const response = await $fetch<unknown>(SPELL_SELECT_CONFIG.searchPath, {
+        method: 'GET',
+        query: {
+          search: debouncedSearchTerm.value.trim() || undefined,
+          page: SPELL_SELECT_CONFIG.page,
+          size: SPELL_SELECT_CONFIG.pageSize,
+          sorting: SPELL_SELECT_CONFIG.sorting,
+        },
+        retry: SPELL_SELECT_CONFIG.retryCount,
+      });
+
+      const parsed = spellSearchSchema.parse(response);
+      const spells = Array.isArray(parsed) ? parsed : parsed.value;
+
+      if (generation === requestGeneration) {
+        searchSpellItems.value = spells.map(toSpellSelectItem);
+      }
+    } catch {
+      if (generation === requestGeneration) {
+        searchSpellItems.value = [];
+      }
+    } finally {
+      if (generation === requestGeneration) {
+        isLoading.value = false;
+      }
+    }
+  }
+
+  /** Дозагружает выбранное заклинание, если его нет на текущей странице поиска. */
+  async function loadSelectedItem(spellUrl: string): Promise<void> {
+    if (!spellUrl) {
+      selectedSpellItem.value = null;
+
+      return;
+    }
+
+    const existingSpellItem = searchSpellItems.value.find(
+      (spell) => spell.value === spellUrl,
+    );
+
+    if (existingSpellItem) {
+      selectedSpellItem.value = existingSpellItem;
+
+      return;
+    }
+
+    try {
+      const response = await $fetch<unknown>(
+        `${SPELL_SELECT_CONFIG.detailBasePath}/${spellUrl}`,
+        {
+          method: 'GET',
+          retry: SPELL_SELECT_CONFIG.retryCount,
+        },
+      );
+
+      const parsed = spellSchema.safeParse(response);
+
+      selectedSpellItem.value = parsed.success
+        ? toSpellSelectItem(parsed.data)
+        : null;
+    } catch {
+      selectedSpellItem.value = null;
+    }
+  }
+
+  /** Нормализует очистку Nuxt UI в пустой URL вместо `null`. */
+  function handleModelValueUpdate(value: string | null | undefined): void {
+    selectedSpellUrl.value = value ?? '';
+  }
+
+  watch(debouncedSearchTerm, () => void loadSearchItems(), { immediate: true });
+
+  watch(selectedSpellUrl, (spellUrl) => void loadSelectedItem(spellUrl), {
+    immediate: true,
+  });
+</script>
+
+<template>
+  <USelectMenu
+    v-model:search-term="searchTerm"
+    :model-value="selectedSpellUrl"
+    :items="spellItems"
+    :loading="isLoading"
+    :disabled
+    :placeholder="SPELL_SELECT_CONFIG.placeholder"
+    label-key="label"
+    value-key="value"
+    ignore-filter
+    searchable
+    clearable
+    :ui="{ itemDescription: 'text-xs text-secondary' }"
+    @update:model-value="handleModelValueUpdate"
+  >
+    <template #item-trailing="{ item: spellItem }">
+      <UBadge
+        color="neutral"
+        variant="subtle"
+      >
+        {{ getSpellSelectLevelLabel(spellItem.level) }}
+      </UBadge>
+    </template>
+  </USelectMenu>
+</template>

--- a/app/shared/ui/select/index.ts
+++ b/app/shared/ui/select/index.ts
@@ -29,6 +29,7 @@ export { default as SelectSkill } from './SelectSkills.vue';
 export { default as SelectSkills } from './SelectSkills.vue';
 export { default as SelectSource } from './SelectSource.vue';
 export { default as SelectSpecies } from './SelectSpecies.vue';
+export { default as SelectSpell } from './SelectSpell.vue';
 export { default as SelectSpellArea } from './SelectSpellArea.vue';
 export { default as SelectSpellLevel } from './SelectSpellLevel.vue';
 export { default as SelectSubclass } from './SelectSubclass.vue';

--- a/app/shared/ui/select/spell-constants.ts
+++ b/app/shared/ui/select/spell-constants.ts
@@ -1,0 +1,19 @@
+export const SPELL_SELECT_CONFIG = {
+  searchPath: '/api/v2/spells/search',
+  detailBasePath: '/api/v2/spells',
+  searchDebounceMilliseconds: 250,
+  page: 0,
+  pageSize: 50,
+  sorting: 'NAME',
+  retryCount: 0,
+  placeholder: 'Выбери заклинание',
+  cantripLabel: 'Заговор',
+  spellLevelSuffix: 'круг',
+};
+
+/** Возвращает краткую подпись круга заклинания для выпадающего списка. */
+export function getSpellSelectLevelLabel(level: number): string {
+  return level === 0
+    ? SPELL_SELECT_CONFIG.cantripLabel
+    : `${level} ${SPELL_SELECT_CONFIG.spellLevelSuffix}`;
+}


### PR DESCRIPTION
## Что сделано

- В редактор вида добавлен выбор врождённых заговоров и заклинаний с уровнем получения.
- Доступные по уровню персонажа заклинания сохраняются отдельно от книги заклинаний.
- В листе персонажа и PDF добавлена отдельная группа «Врождённые».

## Проверки

- `pnpm exec eslint . --fix` — без ошибок; один существующий warning в `VttgVideoPlayer.vue`.
- `pnpm exec vue-tsc -p tsconfig.json --noEmit`.
- pre-commit: ESLint, Stylelint и Vue TypeScript.