### PR TITLE
feat: Добавить выбор боевого стиля в лист персонажа

### DIFF
--- a/app/features/character-sheet/body/ui/SheetClassWizardModal.vue
+++ b/app/features/character-sheet/body/ui/SheetClassWizardModal.vue
@@ -1,20 +1,29 @@
 <script setup lang="ts">
-  import type { ClassChoice, ClassOption, ClassSummary } from '../../model';
+  import type {
+    CharacterFeature,
+    ClassChoice,
+    ClassOption,
+    ClassSummary,
+  } from '../../model';
 
   import { ClassDrawer } from '~classes/drawer';
   import { MarkupRender } from '~ui/markup';
+  import { SelectFeat } from '~ui/select';
 
   import { useCatalogSourceQuery, useCharacterSheet } from '../../composables';
   import {
     ABILITY_LABELS,
     buildClassFeatures,
+    buildFeatFeature,
     CLASS_SOURCES_ASYNC_DATA_KEY,
     CLASSES_DETAIL_BASE_PATH,
     CLASSES_FILTERS_PATH,
     CLASSES_SEARCH_PATH,
     deriveClassResources,
     detectFeatureChoice,
+    FEATS_DETAIL_BASE_PATH,
     FEATURE_ORIGIN_LABELS,
+    FIGHTING_STYLE_FEAT_CATEGORIES,
     getCharacterFeatureId,
     getClassMaxHitPoints,
     getClassSkillChoice,
@@ -24,6 +33,7 @@
     matchClassProficiencies,
     parseClassDetail,
     parseClassOptions,
+    parseFeatDetail,
     resolveChoiceOptions,
     SHEET_SEARCH_LABELS,
     SUBCLASS_SELECTION_MIN_LEVEL,
@@ -108,6 +118,11 @@
 
   /** Черновик выборов-селекторов по id выбора: id → выбранные значения. */
   const selections = ref<Record<string, string[]>>({});
+
+  /** Выбранные черты боевого стиля по id классового умения. */
+  const fightingStyleSelections = ref<Record<string, string>>({});
+
+  const isApplying = ref(false);
 
   const subclassAvailable = computed(
     () => level.value >= SUBCLASS_SELECTION_MIN_LEVEL,
@@ -281,6 +296,7 @@
       description: ClassSummary['features'][number]['description'];
       originLabel: string;
       choiceControl: ClassChoice | null;
+      fightingStyleChoice: boolean;
     }> = [];
 
     const seenKeys = new Set<string>();
@@ -309,6 +325,7 @@
           level: feature.level,
           description: feature.description,
           originLabel,
+          fightingStyleChoice: feature.fightingStyleChoice,
           choiceControl: detectFeatureChoice(
             id,
             feature.description,
@@ -332,6 +349,15 @@
   });
 
   const isNextDisabled = computed(() => !selectedClass.value);
+
+  const isApplyDisabled = computed(
+    () =>
+      isApplying.value
+      || featureRows.value.some(
+        (row) =>
+          row.fightingStyleChoice && !fightingStyleSelections.value[row.id],
+      ),
+  );
 
   function showLoadError() {
     toast.add({
@@ -461,6 +487,7 @@
 
       choices.value = {};
       selections.value = {};
+      fightingStyleSelections.value = {};
       step.value = 'review';
     } catch (error) {
       consola.error('Ошибка загрузки класса:', error);
@@ -474,87 +501,155 @@
     step.value = 'class';
   }
 
-  function handleApply() {
+  /**
+   * Загружает выбранные черты боевого стиля и делает их классовыми записями,
+   * чтобы смена класса удаляла прежний выбор.
+   */
+  function buildFightingStyleFeatures(): Promise<
+    Array<{ feature: CharacterFeature; rowId: string; featName: string }>
+  > {
+    const selectedRows = featureRows.value.filter(
+      (row) => row.fightingStyleChoice,
+    );
+
+    return Promise.all(
+      selectedRows.map(async (row) => {
+        const featUrl = fightingStyleSelections.value[row.id];
+
+        if (!featUrl) {
+          throw new Error(`Fighting style is not selected for ${row.id}`);
+        }
+
+        const response = await $fetch<unknown>(
+          `${FEATS_DETAIL_BASE_PATH}/${featUrl}`,
+          {
+            method: 'GET',
+            retry: 0,
+          },
+        );
+
+        const summary = parseFeatDetail(response);
+
+        if (!summary) {
+          throw new Error(`Invalid fighting style response for ${featUrl}`);
+        }
+
+        return {
+          rowId: row.id,
+          featName: summary.name,
+          feature: {
+            ...buildFeatFeature(summary, false),
+            id: `${row.id}:fighting-style:${summary.url}`,
+          },
+        };
+      }),
+    );
+  }
+
+  async function handleApply() {
     const base = classDetail.value;
 
-    if (!base) {
+    if (!base || isApplyDisabled.value) {
       return;
     }
 
-    const matched = matchClassProficiencies(base.proficiencyText);
+    isApplying.value = true;
 
-    // Выбор владения навыками (уровень класса).
-    const skillsChoice = classChoices.value.find(
-      (choice) => choice.id === 'class-skills',
-    );
+    try {
+      const matched = matchClassProficiencies(base.proficiencyText);
 
-    const proficientSkills: string[] = skillsChoice
-      ? (selections.value['class-skills'] ?? []).slice(0, skillsChoice.count)
-      : [];
+      // Выбор владения навыками (уровень класса).
+      const skillsChoice = classChoices.value.find(
+        (choice) => choice.id === 'class-skills',
+      );
 
-    const chosenTools = selections.value['class-tools'] ?? [];
+      const proficientSkills: string[] = skillsChoice
+        ? (selections.value['class-skills'] ?? []).slice(0, skillsChoice.count)
+        : [];
 
-    // Выборы внутри умений: владение навыком, экспертиза и языки; выбранные
-    // значения также идут в текст умения, чтобы отображаться на листе.
-    const expertiseSkills: string[] = [];
-    const chosenLanguages: string[] = [];
-    const featureChoices: Record<string, string> = { ...choices.value };
+      const chosenTools = selections.value['class-tools'] ?? [];
 
-    for (const row of featureRows.value) {
-      const control = row.choiceControl;
+      // Выборы внутри умений: владение навыком, экспертиза и языки; выбранные
+      // значения также идут в текст умения, чтобы отображаться на листе.
+      const expertiseSkills: string[] = [];
+      const chosenLanguages: string[] = [];
+      const featureChoices: Record<string, string> = { ...choices.value };
 
-      if (!control) {
-        continue;
+      const fightingStyleFeatures = await buildFightingStyleFeatures();
+
+      for (const selection of fightingStyleFeatures) {
+        featureChoices[selection.rowId] = selection.featName;
       }
 
-      const values = selections.value[control.id] ?? [];
+      for (const row of featureRows.value) {
+        const control = row.choiceControl;
 
-      if (!values.length) {
-        continue;
+        if (!control) {
+          continue;
+        }
+
+        const values = selections.value[control.id] ?? [];
+
+        if (!values.length) {
+          continue;
+        }
+
+        if (control.kind === 'skill-proficiency') {
+          proficientSkills.push(...values);
+        } else if (control.kind === 'skill-expertise') {
+          expertiseSkills.push(...values);
+        } else if (control.kind === 'language') {
+          chosenLanguages.push(...values);
+        }
+
+        featureChoices[control.id] = values.join(', ');
       }
 
-      if (control.kind === 'skill-proficiency') {
-        proficientSkills.push(...values);
-      } else if (control.kind === 'skill-expertise') {
-        expertiseSkills.push(...values);
-      } else if (control.kind === 'language') {
-        chosenLanguages.push(...values);
-      }
-
-      featureChoices[control.id] = values.join(', ');
-    }
-
-    setClass({
-      characterClass: {
-        url: base.url,
-        name: base.name,
-        subclassUrl: selectedSubclass.value?.url ?? null,
-        subclassName: subclassDetail.value?.name ?? null,
-        casterType: getSelectedCasterType(base, subclassDetail.value),
+      setClass({
+        characterClass: {
+          url: base.url,
+          name: base.name,
+          subclassUrl: selectedSubclass.value?.url ?? null,
+          subclassName: subclassDetail.value?.name ?? null,
+          casterType: getSelectedCasterType(base, subclassDetail.value),
+          hitDie: base.hitDie,
+        },
+        savingThrows: base.savingThrows,
         hitDie: base.hitDie,
-      },
-      savingThrows: base.savingThrows,
-      hitDie: base.hitDie,
-      proficiencies: {
-        armor: matched.armor,
-        weapons: matched.weapons,
-        tools: [...matched.tools, ...chosenTools],
-        languages: chosenLanguages,
-      },
-      skills: {
-        proficient: [...new Set(proficientSkills)],
-        expertise: [...new Set(expertiseSkills)],
-      },
-      classResources: derivedResources.value,
-      features: buildClassFeatures(
-        base,
-        subclassDetail.value,
-        level.value,
-        featureChoices,
-      ),
-    });
+        proficiencies: {
+          armor: matched.armor,
+          weapons: matched.weapons,
+          tools: [...matched.tools, ...chosenTools],
+          languages: chosenLanguages,
+        },
+        skills: {
+          proficient: [...new Set(proficientSkills)],
+          expertise: [...new Set(expertiseSkills)],
+        },
+        classResources: derivedResources.value,
+        features: [
+          ...buildClassFeatures(
+            base,
+            subclassDetail.value,
+            level.value,
+            featureChoices,
+          ),
+          ...fightingStyleFeatures.map((selection) => selection.feature),
+        ],
+      });
 
-    emit('close');
+      emit('close');
+    } catch (error) {
+      consola.error('Ошибка добавления боевого стиля:', error);
+
+      toast.add({
+        color: 'error',
+        icon: 'tabler:alert-triangle',
+        title: 'Не удалось добавить выбранный боевой стиль',
+      });
+    } finally {
+      isApplying.value = false;
+    }
   }
 
   function handleCancel() {
@@ -898,7 +993,21 @@
               </div>
 
               <div
-                v-if="row.choiceControl"
+                v-if="row.fightingStyleChoice"
+                class="flex flex-col gap-1"
+              >
+                <span class="text-xs text-muted">
+                  Выберите 1 черту категории «Боевой стиль»
+                </span>
+
+                <SelectFeat
+                  v-model="fightingStyleSelections[row.id]"
+                  :categories="FIGHTING_STYLE_FEAT_CATEGORIES"
+                />
+              </div>
+
+              <div
+                v-else-if="row.choiceControl"
                 class="flex flex-col gap-1"
               >
                 <span class="text-xs text-muted">
@@ -965,6 +1074,8 @@
             v-if="step === 'review'"
             label="Применить"
             color="primary"
+            :loading="isApplying"
+            :disabled="isApplyDisabled"
             @click.left.exact.prevent="handleApply"
           />
 

--- a/app/features/character-sheet/body/ui/SheetClassWizardModal.vue
+++ b/app/features/character-sheet/body/ui/SheetClassWizardModal.vue
@@ -21,9 +21,17 @@
     CLASSES_SEARCH_PATH,
     deriveClassResources,
     detectFeatureChoice,
-    FEATS_DETAIL_BASE_PATH,
     FEATURE_ORIGIN_LABELS,
+    fetchFeatDetail,
+    FIGHTING_STYLE_CHOICE_LABEL,
+    FIGHTING_STYLE_CHOICE_REQUIRED_ERROR,
+    FIGHTING_STYLE_ERROR_LOG_MESSAGE,
+    FIGHTING_STYLE_ERROR_TOAST_COLOR,
+    FIGHTING_STYLE_ERROR_TOAST_ICON,
+    FIGHTING_STYLE_ERROR_TOAST_TITLE,
     FIGHTING_STYLE_FEAT_CATEGORIES,
+    FIGHTING_STYLE_FEATURE_ID_SEGMENT,
+    FIGHTING_STYLE_INVALID_RESPONSE_ERROR,
     getCharacterFeatureId,
     getClassMaxHitPoints,
     getClassSkillChoice,
@@ -33,7 +41,6 @@
     matchClassProficiencies,
     parseClassDetail,
     parseClassOptions,
-    parseFeatDetail,
     resolveChoiceOptions,
     SHEET_SEARCH_LABELS,
     SUBCLASS_SELECTION_MIN_LEVEL,
@@ -122,7 +129,7 @@
   /** Выбранные черты боевого стиля по id классового умения. */
   const fightingStyleSelections = ref<Record<string, string>>({});
 
-  const isApplying = ref(false);
+  const isApplying = shallowRef(false);
 
   const subclassAvailable = computed(
     () => level.value >= SUBCLASS_SELECTION_MIN_LEVEL,
@@ -517,35 +524,28 @@
         const featUrl = fightingStyleSelections.value[row.id];
 
         if (!featUrl) {
-          throw new Error(`Fighting style is not selected for ${row.id}`);
+          throw new Error(FIGHTING_STYLE_CHOICE_REQUIRED_ERROR);
         }
 
-        const response = await $fetch<unknown>(
-          `${FEATS_DETAIL_BASE_PATH}/${featUrl}`,
-          {
-            method: 'GET',
-            retry: 0,
-          },
-        );
-
-        const summary = parseFeatDetail(response);
+        const summary = await fetchFeatDetail(featUrl);
 
         if (!summary) {
-          throw new Error(`Invalid fighting style response for ${featUrl}`);
+          throw new Error(FIGHTING_STYLE_INVALID_RESPONSE_ERROR);
         }
 
         return {
           rowId: row.id,
           featName: summary.name,
           feature: {
-            ...buildFeatFeature(summary, false),
-            id: `${row.id}:fighting-style:${summary.url}`,
+            ...buildFeatFeature(summary),
+            id: `${row.id}:${FIGHTING_STYLE_FEATURE_ID_SEGMENT}:${summary.url}`,
           },
         };
       }),
     );
   }
 
+  /** Применяет выбранный класс и все связанные с ним выборы к листу. */
   async function handleApply() {
     const base = classDetail.value;
 
@@ -640,12 +640,12 @@
 
       emit('close');
     } catch (error) {
-      consola.error('Ошибка добавления боевого стиля:', error);
+      consola.error(FIGHTING_STYLE_ERROR_LOG_MESSAGE, error);
 
       toast.add({
-        color: 'error',
-        icon: 'tabler:alert-triangle',
-        title: 'Не удалось добавить выбранный боевой стиль',
+        color: FIGHTING_STYLE_ERROR_TOAST_COLOR,
+        icon: FIGHTING_STYLE_ERROR_TOAST_ICON,
+        title: FIGHTING_STYLE_ERROR_TOAST_TITLE,
       });
     } finally {
       isApplying.value = false;
@@ -997,7 +997,7 @@
                 class="flex flex-col gap-1"
               >
                 <span class="text-xs text-muted">
-                  Выберите 1 черту категории «Боевой стиль»
+                  {{ FIGHTING_STYLE_CHOICE_LABEL }}
                 </span>
 
                 <SelectFeat

--- a/app/features/character-sheet/body/ui/SheetFeatAddModal.vue
+++ b/app/features/character-sheet/body/ui/SheetFeatAddModal.vue
@@ -6,13 +6,12 @@
   import { useCatalogSourceQuery, useCharacterSheet } from '../../composables';
   import {
     buildFeatFeature,
-    FEATS_DETAIL_BASE_PATH,
     FEATS_FILTERS_PATH,
     FEATS_SEARCH_PATH,
     FEATS_SELECT_PATH,
+    fetchFeatDetail,
     getFeatUrlFromFeatureId,
     parseFeatCatalog,
-    parseFeatDetail,
     parseRepeatableFeatUrls,
     SHEET_SEARCH_LABELS,
   } from '../../model';
@@ -211,16 +210,6 @@
     }
 
     draftUrls.value = nextUrls;
-  }
-
-  /** Загружает деталь черты по url; null — ответ не распознан. */
-  async function fetchFeatDetail(url: string): Promise<FeatSummary | null> {
-    const response = await $fetch<unknown>(`${FEATS_DETAIL_BASE_PATH}/${url}`, {
-      method: 'GET',
-      retry: 0,
-    });
-
-    return parseFeatDetail(response);
   }
 
   async function handleApply() {

--- a/app/features/character-sheet/model/api.ts
+++ b/app/features/character-sheet/model/api.ts
@@ -4,6 +4,7 @@ import type {
   CharacterInventoryItem,
   CharacterSheetDetail,
   CharacterSheetListPage,
+  FeatSummary,
   FeatureDescriptionNode,
   SavedCharacterSheet,
   SavedCharacterSheetListPage,
@@ -22,10 +23,15 @@ import {
   CHARACTER_SHEET_API_PATH,
   CHARACTER_SHEET_SAVED_API_PATH,
   CHARACTER_SHEET_SHARED_API_PATH,
+  FEATS_DETAIL_BASE_PATH,
   SHEET_UNKNOWN_ERROR_MESSAGE,
   SPELLS_DETAIL_BASE_PATH,
 } from './constants';
-import { parseCatalogDescription, parseCatalogSpellDetail } from './schemas';
+import {
+  parseCatalogDescription,
+  parseCatalogSpellDetail,
+  parseFeatDetail,
+} from './schemas';
 import { getInventoryItemDetailPath } from './utils';
 
 /**
@@ -47,6 +53,26 @@ export function getSheetErrorMessage(error: unknown): string {
   }
 
   return SHEET_UNKNOWN_ERROR_MESSAGE;
+}
+
+/**
+ * Загружает и валидирует детальную информацию о черте из каталога.
+ *
+ * @param featUrl URL черты в каталоге.
+ * @returns разобранная черта или null, если ответ не соответствует контракту.
+ */
+export async function fetchFeatDetail(
+  featUrl: string,
+): Promise<FeatSummary | null> {
+  const response = await $fetch<unknown>(
+    `${FEATS_DETAIL_BASE_PATH}/${featUrl}`,
+    {
+      method: 'GET',
+      retry: 0,
+    },
+  );
+
+  return parseFeatDetail(response);
 }
 
 /**

--- a/app/features/character-sheet/model/constants.ts
+++ b/app/features/character-sheet/model/constants.ts
@@ -1108,6 +1108,28 @@ export const FEATS_DETAIL_BASE_PATH = '/api/v2/feats';
 /** Категория черт, доступных через классовое умение выбора боевого стиля. */
 export const FIGHTING_STYLE_FEAT_CATEGORIES = ['FIGHTING_STYLE'];
 
+/** Тексты и технические значения выбора боевого стиля в мастере класса. */
+export const FIGHTING_STYLE_CHOICE_LABEL =
+  'Выберите 1 черту категории «Боевой стиль»';
+
+export const FIGHTING_STYLE_CHOICE_REQUIRED_ERROR =
+  'Не выбран обязательный боевой стиль';
+
+export const FIGHTING_STYLE_INVALID_RESPONSE_ERROR =
+  'Сервер вернул некорректную черту боевого стиля';
+
+export const FIGHTING_STYLE_FEATURE_ID_SEGMENT = 'fighting-style';
+
+export const FIGHTING_STYLE_ERROR_TOAST_COLOR = 'error';
+
+export const FIGHTING_STYLE_ERROR_TOAST_ICON = 'tabler:alert-triangle';
+
+export const FIGHTING_STYLE_ERROR_TOAST_TITLE =
+  'Не удалось добавить выбранный боевой стиль';
+
+export const FIGHTING_STYLE_ERROR_LOG_MESSAGE =
+  'Ошибка добавления боевого стиля:';
+
 /** Эндпоинт фильтров черт — источник глобальной настройки источников. */
 export const FEATS_FILTERS_PATH = '/api/v2/feats/filters';
 

--- a/app/features/character-sheet/model/constants.ts
+++ b/app/features/character-sheet/model/constants.ts
@@ -1105,6 +1105,9 @@ export const FEATS_SELECT_PATH = '/api/v2/feats/select';
 /** Базовый путь деталей черты (`/{url}`). */
 export const FEATS_DETAIL_BASE_PATH = '/api/v2/feats';
 
+/** Категория черт, доступных через классовое умение выбора боевого стиля. */
+export const FIGHTING_STYLE_FEAT_CATEGORIES = ['FIGHTING_STYLE'];
+
 /** Эндпоинт фильтров черт — источник глобальной настройки источников. */
 export const FEATS_FILTERS_PATH = '/api/v2/feats/filters';
 

--- a/app/features/character-sheet/model/schemas.ts
+++ b/app/features/character-sheet/model/schemas.ts
@@ -700,6 +700,7 @@ const classFeatureSchema = z.object({
   name: z.string().catch(''),
   description: renderNodeSchema,
   isSubclass: z.boolean().catch(false),
+  fightingStyleChoice: z.boolean().catch(false),
 });
 
 /** Схема детального ответа класса или подкласса (нужные листу поля). */
@@ -744,6 +745,7 @@ function toClassSummary(
     name: feature.name,
     description: toDescriptionNodes(feature.description),
     isSubclass: feature.isSubclass,
+    fightingStyleChoice: feature.fightingStyleChoice,
   }));
 
   const table: ClassTableColumn[] = detail.table.map((column) => ({

--- a/app/features/character-sheet/model/types.ts
+++ b/app/features/character-sheet/model/types.ts
@@ -737,6 +737,9 @@ export interface ClassFeatureSummary {
 
   /** Особенность подкласса (а не базового класса). */
   isSubclass: boolean;
+
+  /** Умение даёт выбор одной черты категории «Боевой стиль». */
+  fightingStyleChoice: boolean;
 }
 
 /** Колонка таблицы прогрессии класса (для вывода ресурсов). */

--- a/app/features/classes/body/ui/table/ClassTable.vue
+++ b/app/features/classes/body/ui/table/ClassTable.vue
@@ -79,6 +79,7 @@
           ...feature.scaling.map((scale) => ({
             key: feature.key,
             isSubclass: feature.isSubclass,
+            fightingStyleChoice: false,
             ...scale,
           })),
         );

--- a/app/features/classes/body/ui/table/MulticlassTable.vue
+++ b/app/features/classes/body/ui/table/MulticlassTable.vue
@@ -102,6 +102,7 @@
           ...feature.scaling.map((scale) => ({
             key: feature.key,
             isSubclass: feature.isSubclass,
+            fightingStyleChoice: false,
             ...scale,
             anchorId,
           })),

--- a/app/features/classes/editor/ui/FeaturesEditor.vue
+++ b/app/features/classes/editor/ui/FeaturesEditor.vue
@@ -6,6 +6,10 @@
   import { SelectLevel } from '~ui/select';
 
   import {
+    CLASS_FEATURE_FIGHTING_STYLE_DESCRIPTION,
+    CLASS_FEATURE_FIGHTING_STYLE_LABEL,
+  } from '../../model';
+  import {
     FeatureAbilityBonus,
     FeatureOptions,
     FeatureScaling,
@@ -139,7 +143,7 @@
             />
 
             <UFormField
-              class="col-span-full md:col-span-18"
+              class="col-span-full md:col-span-12"
               label="Подсказка"
               name="additional"
             >
@@ -162,12 +166,12 @@
 
             <UFormField
               class="col-span-full md:col-span-6"
-              label="Даёт выбор боевого стиля?"
+              :label="CLASS_FEATURE_FIGHTING_STYLE_LABEL"
               name="fightingStyleChoice"
             >
               <UCheckbox
                 v-model="feat.fightingStyleChoice"
-                description="Да"
+                :description="CLASS_FEATURE_FIGHTING_STYLE_DESCRIPTION"
               />
             </UFormField>
 

--- a/app/features/classes/editor/ui/FeaturesEditor.vue
+++ b/app/features/classes/editor/ui/FeaturesEditor.vue
@@ -54,6 +54,7 @@
       additional: '',
       hideInSubclasses: false,
       abilityImprovement: false,
+      fightingStyleChoice: false,
       scaling: [],
       options: [],
       abilityBonus: {
@@ -155,6 +156,17 @@
             >
               <UCheckbox
                 v-model="feat.abilityImprovement"
+                description="Да"
+              />
+            </UFormField>
+
+            <UFormField
+              class="col-span-full md:col-span-6"
+              label="Даёт выбор боевого стиля?"
+              name="fightingStyleChoice"
+            >
+              <UCheckbox
+                v-model="feat.fightingStyleChoice"
                 description="Да"
               />
             </UFormField>

--- a/app/features/classes/model/constants.ts
+++ b/app/features/classes/model/constants.ts
@@ -8,3 +8,8 @@ export const CLASS_RESOURCE_RECOVERY_OPTIONS: Array<{
   { label: 'Короткий отдых', value: 'SHORT_REST' },
   { label: 'Продолжительный отдых', value: 'LONG_REST' },
 ];
+
+/** Подписи настройки выбора боевого стиля в редакторе умения класса. */
+export const CLASS_FEATURE_FIGHTING_STYLE_LABEL = 'Даёт выбор боевого стиля?';
+
+export const CLASS_FEATURE_FIGHTING_STYLE_DESCRIPTION = 'Да';

--- a/app/features/classes/model/create.ts
+++ b/app/features/classes/model/create.ts
@@ -34,6 +34,7 @@ export interface ClassFeatureCreate {
   additional: string;
   hideInSubclasses: boolean | undefined;
   abilityImprovement: boolean | undefined;
+  fightingStyleChoice: boolean | undefined;
   scaling: Array<ClassFeatureScalingCreate>;
   options: Array<ClassFeatureOptionCreate>;
   abilityBonus?: ClassFeatureAbilityBonusCreate;

--- a/app/features/classes/model/detail.ts
+++ b/app/features/classes/model/detail.ts
@@ -79,6 +79,7 @@ export interface ClassFeature {
   description: RenderNode;
   additional: string;
   isSubclass?: boolean;
+  fightingStyleChoice: boolean;
   scaling?: Array<{
     level: Level;
     name: string;

--- a/app/features/classes/model/schema.ts
+++ b/app/features/classes/model/schema.ts
@@ -108,6 +108,7 @@ const classFeatureSchema: z.ZodType<ClassFeature> = z.object({
   description: renderNodeSchema,
   additional: z.string(),
   isSubclass: z.boolean().optional(),
+  fightingStyleChoice: z.boolean().catch(false),
   scaling: z
     .array(
       z.object({


### PR DESCRIPTION
## Что сделано

- в редактор классов добавлен чекбокс «Даёт выбор боевого стиля?»;
- в мастере выбора класса для каждого доступного отмеченного умения добавлен обязательный выбор одной черты категории `FIGHTING_STYLE`;
- выбранная черта сохраняется как классовая особенность и удаляется или заменяется при смене класса;
- старые ответы API без нового признака обрабатываются со значением `false`.

## Зачем

Выбор боевого стиля должен зависеть от настройки умения в редакторе, а не от текста или названия умения.

## Проверка

- ESLint без ошибок;
- `vue-tsc` успешно;
- pre-commit: ESLint, TypeScript и Stylelint успешно;
- `git diff --check` успешно.