### PR TITLE
fix(character-sheet): доработать выбор боевого стиля по итогам ревью

### DIFF
--- a/app/features/character-sheet/body/ui/SheetClassWizardModal.vue
+++ b/app/features/character-sheet/body/ui/SheetClassWizardModal.vue
@@ -21,14 +21,11 @@
     CLASSES_SEARCH_PATH,
     deriveClassResources,
     detectFeatureChoice,
+    FEAT_SOURCES_ASYNC_DATA_KEY,
+    FEATS_FILTERS_PATH,
     FEATURE_ORIGIN_LABELS,
     fetchFeatDetail,
     FIGHTING_STYLE_CHOICE_LABEL,
-    FIGHTING_STYLE_CHOICE_REQUIRED_ERROR,
-    FIGHTING_STYLE_ERROR_LOG_MESSAGE,
-    FIGHTING_STYLE_ERROR_TOAST_COLOR,
-    FIGHTING_STYLE_ERROR_TOAST_ICON,
-    FIGHTING_STYLE_ERROR_TOAST_TITLE,
     FIGHTING_STYLE_FEAT_CATEGORIES,
     FIGHTING_STYLE_FEATURE_ID_SEGMENT,
     FIGHTING_STYLE_INVALID_RESPONSE_ERROR,
@@ -50,6 +47,18 @@
   import SheetSearchInput from './SheetSearchInput.vue';
 
   type WizardStep = 'class' | 'review';
+
+  /** Загруженная черта боевого стиля и умение класса, к которому она выбрана. */
+  interface FightingStyleSelection {
+    /** Идентификатор строки умения класса (`class:{featureKey}`). */
+    rowId: string;
+
+    /** Название черты — идёт в подпись выбора у самого умения. */
+    featName: string;
+
+    /** Готовая запись особенности для листа. */
+    feature: CharacterFeature;
+  }
 
   const emit = defineEmits<{
     close: [];
@@ -80,11 +89,15 @@
 
   // Источники берутся из глобальной настройки профиля — визард не показывает
   // классы из отключённых книг. Запрос ждём до списка: иначе первая выдача
-  // пришла бы по всем источникам и мигнула лишними строками.
-  const { sourceQuery } = await useCatalogSourceQuery(
-    CLASS_SOURCES_ASYNC_DATA_KEY,
-    CLASSES_FILTERS_PATH,
-  );
+  // пришла бы по всем источникам и мигнула лишними строками. Черты боевого
+  // стиля отбираются теми же источниками, но их эндпоинт `/feats/select` по
+  // источникам не фильтрует, поэтому отбор идёт на клиенте — в селекторе.
+  // Оба набора фильтров грузятся параллельно: открытие визарда ждёт их обоих.
+  const [{ sourceQuery }, { selectedSourceIds: featSourceIds }] =
+    await Promise.all([
+      useCatalogSourceQuery(CLASS_SOURCES_ASYNC_DATA_KEY, CLASSES_FILTERS_PATH),
+      useCatalogSourceQuery(FEAT_SOURCES_ASYNC_DATA_KEY, FEATS_FILTERS_PATH),
+    ]);
 
   // Полный список классов загружается сразу при открытии визарда.
   const { data: classList, status: listStatus } = await useAsyncData(
@@ -374,6 +387,14 @@
     });
   }
 
+  function showFightingStyleError() {
+    toast.add({
+      color: 'error',
+      icon: 'tabler:alert-triangle',
+      title: 'Не удалось добавить выбранный боевой стиль',
+    });
+  }
+
   function findClassOption(classUrl: string): ClassOption | undefined {
     return (classList.value ?? []).find((option) => option.url === classUrl);
   }
@@ -510,23 +531,24 @@
 
   /**
    * Загружает выбранные черты боевого стиля и делает их классовыми записями,
-   * чтобы смена класса удаляла прежний выбор.
+   * чтобы смена класса удаляла прежний выбор. Строки без выбора пропускаются:
+   * применение до полного выбора блокирует `isApplyDisabled`.
    */
   function buildFightingStyleFeatures(): Promise<
-    Array<{ feature: CharacterFeature; rowId: string; featName: string }>
+    Array<FightingStyleSelection>
   > {
-    const selectedRows = featureRows.value.filter(
-      (row) => row.fightingStyleChoice,
-    );
+    const selectedRows: Array<{ rowId: string; featUrl: string }> = [];
+
+    for (const row of featureRows.value) {
+      const featUrl = fightingStyleSelections.value[row.id];
+
+      if (row.fightingStyleChoice && featUrl) {
+        selectedRows.push({ rowId: row.id, featUrl });
+      }
+    }
 
     return Promise.all(
-      selectedRows.map(async (row) => {
-        const featUrl = fightingStyleSelections.value[row.id];
-
-        if (!featUrl) {
-          throw new Error(FIGHTING_STYLE_CHOICE_REQUIRED_ERROR);
-        }
-
+      selectedRows.map(async ({ rowId, featUrl }) => {
         const summary = await fetchFeatDetail(featUrl);
 
         if (!summary) {
@@ -534,11 +556,11 @@
         }
 
         return {
-          rowId: row.id,
+          rowId,
           featName: summary.name,
           feature: {
             ...buildFeatFeature(summary),
-            id: `${row.id}:${FIGHTING_STYLE_FEATURE_ID_SEGMENT}:${summary.url}`,
+            id: `${rowId}:${FIGHTING_STYLE_FEATURE_ID_SEGMENT}:${summary.url}`,
           },
         };
       }),
@@ -555,101 +577,103 @@
 
     isApplying.value = true;
 
+    // Под `try` только загрузка черт: ошибка сети не должна выглядеть как сбой
+    // применения класса, а применение ниже — синхронное и не бросает.
+    let fightingStyleFeatures: Array<FightingStyleSelection>;
+
     try {
-      const matched = matchClassProficiencies(base.proficiencyText);
-
-      // Выбор владения навыками (уровень класса).
-      const skillsChoice = classChoices.value.find(
-        (choice) => choice.id === 'class-skills',
-      );
-
-      const proficientSkills: string[] = skillsChoice
-        ? (selections.value['class-skills'] ?? []).slice(0, skillsChoice.count)
-        : [];
-
-      const chosenTools = selections.value['class-tools'] ?? [];
-
-      // Выборы внутри умений: владение навыком, экспертиза и языки; выбранные
-      // значения также идут в текст умения, чтобы отображаться на листе.
-      const expertiseSkills: string[] = [];
-      const chosenLanguages: string[] = [];
-      const featureChoices: Record<string, string> = { ...choices.value };
-
-      const fightingStyleFeatures = await buildFightingStyleFeatures();
-
-      for (const selection of fightingStyleFeatures) {
-        featureChoices[selection.rowId] = selection.featName;
-      }
-
-      for (const row of featureRows.value) {
-        const control = row.choiceControl;
-
-        if (!control) {
-          continue;
-        }
-
-        const values = selections.value[control.id] ?? [];
-
-        if (!values.length) {
-          continue;
-        }
-
-        if (control.kind === 'skill-proficiency') {
-          proficientSkills.push(...values);
-        } else if (control.kind === 'skill-expertise') {
-          expertiseSkills.push(...values);
-        } else if (control.kind === 'language') {
-          chosenLanguages.push(...values);
-        }
-
-        featureChoices[control.id] = values.join(', ');
-      }
-
-      setClass({
-        characterClass: {
-          url: base.url,
-          name: base.name,
-          subclassUrl: selectedSubclass.value?.url ?? null,
-          subclassName: subclassDetail.value?.name ?? null,
-          casterType: getSelectedCasterType(base, subclassDetail.value),
-          hitDie: base.hitDie,
-        },
-        savingThrows: base.savingThrows,
-        hitDie: base.hitDie,
-        proficiencies: {
-          armor: matched.armor,
-          weapons: matched.weapons,
-          tools: [...matched.tools, ...chosenTools],
-          languages: chosenLanguages,
-        },
-        skills: {
-          proficient: [...new Set(proficientSkills)],
-          expertise: [...new Set(expertiseSkills)],
-        },
-        classResources: derivedResources.value,
-        features: [
-          ...buildClassFeatures(
-            base,
-            subclassDetail.value,
-            level.value,
-            featureChoices,
-          ),
-          ...fightingStyleFeatures.map((selection) => selection.feature),
-        ],
-      });
-
-      emit('close');
+      fightingStyleFeatures = await buildFightingStyleFeatures();
     } catch (error) {
-      consola.error(FIGHTING_STYLE_ERROR_LOG_MESSAGE, error);
+      consola.error('Ошибка добавления боевого стиля:', error);
 
-      toast.add({
-        color: FIGHTING_STYLE_ERROR_TOAST_COLOR,
-        icon: FIGHTING_STYLE_ERROR_TOAST_ICON,
-        title: FIGHTING_STYLE_ERROR_TOAST_TITLE,
-      });
+      showFightingStyleError();
+
+      return;
     } finally {
       isApplying.value = false;
     }
+
+    const matched = matchClassProficiencies(base.proficiencyText);
+
+    // Выбор владения навыками (уровень класса).
+    const skillsChoice = classChoices.value.find(
+      (choice) => choice.id === 'class-skills',
+    );
+
+    const proficientSkills: string[] = skillsChoice
+      ? (selections.value['class-skills'] ?? []).slice(0, skillsChoice.count)
+      : [];
+
+    const chosenTools = selections.value['class-tools'] ?? [];
+
+    // Выборы внутри умений: владение навыком, экспертиза и языки; выбранные
+    // значения также идут в текст умения, чтобы отображаться на листе.
+    const expertiseSkills: string[] = [];
+    const chosenLanguages: string[] = [];
+    const featureChoices: Record<string, string> = { ...choices.value };
+
+    for (const selection of fightingStyleFeatures) {
+      featureChoices[selection.rowId] = selection.featName;
+    }
+
+    for (const row of featureRows.value) {
+      const control = row.choiceControl;
+
+      if (!control) {
+        continue;
+      }
+
+      const values = selections.value[control.id] ?? [];
+
+      if (!values.length) {
+        continue;
+      }
+
+      if (control.kind === 'skill-proficiency') {
+        proficientSkills.push(...values);
+      } else if (control.kind === 'skill-expertise') {
+        expertiseSkills.push(...values);
+      } else if (control.kind === 'language') {
+        chosenLanguages.push(...values);
+      }
+
+      featureChoices[control.id] = values.join(', ');
+    }
+
+    setClass({
+      characterClass: {
+        url: base.url,
+        name: base.name,
+        subclassUrl: selectedSubclass.value?.url ?? null,
+        subclassName: subclassDetail.value?.name ?? null,
+        casterType: getSelectedCasterType(base, subclassDetail.value),
+        hitDie: base.hitDie,
+      },
+      savingThrows: base.savingThrows,
+      hitDie: base.hitDie,
+      proficiencies: {
+        armor: matched.armor,
+        weapons: matched.weapons,
+        tools: [...matched.tools, ...chosenTools],
+        languages: chosenLanguages,
+      },
+      skills: {
+        proficient: [...new Set(proficientSkills)],
+        expertise: [...new Set(expertiseSkills)],
+      },
+      classResources: derivedResources.value,
+      features: [
+        ...buildClassFeatures(
+          base,
+          subclassDetail.value,
+          level.value,
+          featureChoices,
+        ),
+        ...fightingStyleFeatures.map((selection) => selection.feature),
+      ],
+    });
+
+    emit('close');
   }
 
   function handleCancel() {
@@ -1003,6 +1027,7 @@
                 <SelectFeat
                   v-model="fightingStyleSelections[row.id]"
                   :categories="FIGHTING_STYLE_FEAT_CATEGORIES"
+                  :sources="featSourceIds"
                 />
               </div>
 

--- a/app/features/character-sheet/body/ui/SheetFeatAddModal.vue
+++ b/app/features/character-sheet/body/ui/SheetFeatAddModal.vue
@@ -6,6 +6,7 @@
   import { useCatalogSourceQuery, useCharacterSheet } from '../../composables';
   import {
     buildFeatFeature,
+    FEAT_SOURCES_ASYNC_DATA_KEY,
     FEATS_FILTERS_PATH,
     FEATS_SEARCH_PATH,
     FEATS_SELECT_PATH,
@@ -44,7 +45,7 @@
   // черты из отключённых книг. Запрос ждём до списка: иначе первая выдача
   // пришла бы по всем источникам и мигнула лишними строками.
   const { sourceQuery } = await useCatalogSourceQuery(
-    'character-sheet:feat-sources',
+    FEAT_SOURCES_ASYNC_DATA_KEY,
     FEATS_FILTERS_PATH,
   );
 

--- a/app/features/character-sheet/model/constants.ts
+++ b/app/features/character-sheet/model/constants.ts
@@ -1108,30 +1108,30 @@ export const FEATS_DETAIL_BASE_PATH = '/api/v2/feats';
 /** Категория черт, доступных через классовое умение выбора боевого стиля. */
 export const FIGHTING_STYLE_FEAT_CATEGORIES = ['FIGHTING_STYLE'];
 
-/** Тексты и технические значения выбора боевого стиля в мастере класса. */
+/** Подпись выбора боевого стиля в визарде класса. */
 export const FIGHTING_STYLE_CHOICE_LABEL =
   'Выберите 1 черту категории «Боевой стиль»';
 
-export const FIGHTING_STYLE_CHOICE_REQUIRED_ERROR =
-  'Не выбран обязательный боевой стиль';
-
+/** Ошибка: деталь выбранной черты не прошла разбор по схеме. */
 export const FIGHTING_STYLE_INVALID_RESPONSE_ERROR =
   'Сервер вернул некорректную черту боевого стиля';
 
+/**
+ * Сегмент идентификатора особенности с выбранным боевым стилем:
+ * `class:{featureKey}:fighting-style:{featUrl}`. Префикс `class:` нужен, чтобы
+ * смена класса удаляла прежний выбор, а сегмент — чтобы из идентификатора
+ * можно было достать url черты.
+ */
 export const FIGHTING_STYLE_FEATURE_ID_SEGMENT = 'fighting-style';
-
-export const FIGHTING_STYLE_ERROR_TOAST_COLOR = 'error';
-
-export const FIGHTING_STYLE_ERROR_TOAST_ICON = 'tabler:alert-triangle';
-
-export const FIGHTING_STYLE_ERROR_TOAST_TITLE =
-  'Не удалось добавить выбранный боевой стиль';
-
-export const FIGHTING_STYLE_ERROR_LOG_MESSAGE =
-  'Ошибка добавления боевого стиля:';
 
 /** Эндпоинт фильтров черт — источник глобальной настройки источников. */
 export const FEATS_FILTERS_PATH = '/api/v2/feats/filters';
+
+/**
+ * Ключ `useAsyncData` для источников каталога черт. Общий у модалки черт и
+ * визарда класса: ответ фильтров переиспользуется между модалками.
+ */
+export const FEAT_SOURCES_ASYNC_DATA_KEY = 'character-sheet:feat-sources';
 
 /** Эндпоинт поиска видов. */
 export const SPECIES_SEARCH_PATH = '/api/v2/species/search';

--- a/app/features/character-sheet/model/utils.ts
+++ b/app/features/character-sheet/model/utils.ts
@@ -127,6 +127,7 @@ import {
   DEFAULT_WEAPON_ATTACK_ABILITY,
   DICE_NOTATION_LETTER,
   FEATURE_ORIGIN_LABELS,
+  FIGHTING_STYLE_FEATURE_ID_SEGMENT,
   HIT_DICE_ROLL_COUNT,
   HIT_POINTS_LEVEL_GAIN_MIN,
   INVENTORY_CATEGORY_ORDER,
@@ -2174,11 +2175,21 @@ export function getCharacterFeatureId(
  * Извлекает url черты из идентификатора особенности. Обычная черта — `feat:url`,
  * повторяемая — `feat:url:uuid` (у каждой копии свой суффикс). Url черты не
  * содержит двоеточий, поэтому берём сегмент между первым и вторым `:`.
+ * Боевой стиль лежит под классовым идентификатором
+ * (`class:{featureKey}:fighting-style:{url}`) — иначе его копия не удалялась бы
+ * при смене класса, — поэтому url берётся из хвоста после сегмента.
  *
  * @param featureId идентификатор особенности.
  * @returns url черты или null, если особенность — не черта.
  */
 export function getFeatUrlFromFeatureId(featureId: string): string | null {
+  const fightingStyleSegment = `:${FIGHTING_STYLE_FEATURE_ID_SEGMENT}:`;
+  const fightingStyleIndex = featureId.indexOf(fightingStyleSegment);
+
+  if (fightingStyleIndex !== -1) {
+    return featureId.slice(fightingStyleIndex + fightingStyleSegment.length);
+  }
+
   if (!featureId.startsWith('feat:')) {
     return null;
   }

--- a/app/features/classes/body/ui/table/ClassTable.vue
+++ b/app/features/classes/body/ui/table/ClassTable.vue
@@ -79,7 +79,6 @@
           ...feature.scaling.map((scale) => ({
             key: feature.key,
             isSubclass: feature.isSubclass,
-            fightingStyleChoice: false,
             ...scale,
           })),
         );

--- a/app/features/classes/body/ui/table/MulticlassTable.vue
+++ b/app/features/classes/body/ui/table/MulticlassTable.vue
@@ -102,7 +102,6 @@
           ...feature.scaling.map((scale) => ({
             key: feature.key,
             isSubclass: feature.isSubclass,
-            fightingStyleChoice: false,
             ...scale,
             anchorId,
           })),

--- a/app/features/classes/editor/ui/FeaturesEditor.vue
+++ b/app/features/classes/editor/ui/FeaturesEditor.vue
@@ -6,10 +6,6 @@
   import { SelectLevel } from '~ui/select';
 
   import {
-    CLASS_FEATURE_FIGHTING_STYLE_DESCRIPTION,
-    CLASS_FEATURE_FIGHTING_STYLE_LABEL,
-  } from '../../model';
-  import {
     FeatureAbilityBonus,
     FeatureOptions,
     FeatureScaling,
@@ -166,12 +162,12 @@
 
             <UFormField
               class="col-span-full md:col-span-6"
-              :label="CLASS_FEATURE_FIGHTING_STYLE_LABEL"
+              label="Даёт выбор боевого стиля?"
               name="fightingStyleChoice"
             >
               <UCheckbox
                 v-model="feat.fightingStyleChoice"
-                :description="CLASS_FEATURE_FIGHTING_STYLE_DESCRIPTION"
+                description="Да"
               />
             </UFormField>
 

--- a/app/features/classes/model/constants.ts
+++ b/app/features/classes/model/constants.ts
@@ -8,8 +8,3 @@ export const CLASS_RESOURCE_RECOVERY_OPTIONS: Array<{
   { label: 'Короткий отдых', value: 'SHORT_REST' },
   { label: 'Продолжительный отдых', value: 'LONG_REST' },
 ];
-
-/** Подписи настройки выбора боевого стиля в редакторе умения класса. */
-export const CLASS_FEATURE_FIGHTING_STYLE_LABEL = 'Даёт выбор боевого стиля?';
-
-export const CLASS_FEATURE_FIGHTING_STYLE_DESCRIPTION = 'Да';

--- a/app/features/classes/model/detail.ts
+++ b/app/features/classes/model/detail.ts
@@ -79,7 +79,7 @@ export interface ClassFeature {
   description: RenderNode;
   additional: string;
   isSubclass?: boolean;
-  fightingStyleChoice: boolean;
+  fightingStyleChoice?: boolean;
   scaling?: Array<{
     level: Level;
     name: string;

--- a/app/shared/ui/select/SelectFeat.vue
+++ b/app/shared/ui/select/SelectFeat.vue
@@ -43,6 +43,12 @@
       multiple?: boolean;
       categories?: Array<string>;
       excludeUrls?: Array<string>;
+      /**
+       * Идентификаторы разрешённых источников (`['PHB']`). Эндпоинт `/select`
+       * по источникам не фильтрует, поэтому отбор идёт на клиенте. Пустой
+       * список означает, что ограничения нет.
+       */
+      sources?: Array<string>;
       max?: number;
     }>(),
     {
@@ -50,6 +56,7 @@
       multiple: false,
       categories: undefined,
       excludeUrls: () => [],
+      sources: () => [],
       max: undefined,
     },
   );
@@ -67,6 +74,21 @@
 
   const excludeKey = computed<string>(() => props.excludeUrls.join(','));
 
+  const sourcesKey = computed<string>(() => props.sources.join(','));
+
+  /** Черта уже выбрана в модели (одиночный или множественный выбор). */
+  function isSelectedUrl(featUrl: string): boolean {
+    if (typeof model.value === 'string') {
+      return model.value === featUrl;
+    }
+
+    if (Array.isArray(model.value)) {
+      return model.value.includes(featUrl);
+    }
+
+    return false;
+  }
+
   const requestCategories = computed<string | undefined>(() => {
     if (categoriesList.value.length === 0) {
       return undefined;
@@ -76,7 +98,7 @@
   });
 
   const asyncDataKey = computed<string>(() => {
-    return `feats-select:${categoriesKey.value}:${excludeKey.value}`;
+    return `feats-select:${categoriesKey.value}:${excludeKey.value}:${sourcesKey.value}`;
   });
 
   const { data, status, refresh } = await useAsyncData<Array<FeatSelectItem>>(
@@ -95,23 +117,23 @@
       );
 
       const excluded = new Set(props.excludeUrls);
+      const allowedSources = new Set(props.sources);
 
       return featLinks
         .filter((feat) => {
-          if (!excluded.has(feat.url)) {
+          // если значение уже выбрано — оставляем его видимым
+          if (isSelectedUrl(feat.url)) {
             return true;
           }
 
-          // если значение уже выбрано — оставляем его видимым
-          if (typeof model.value === 'string') {
-            return model.value === feat.url;
+          if (
+            allowedSources.size > 0
+            && !allowedSources.has(feat.source.name.label)
+          ) {
+            return false;
           }
 
-          if (Array.isArray(model.value)) {
-            return model.value.includes(feat.url);
-          }
-
-          return false;
+          return !excluded.has(feat.url);
         })
         .map((feat) => {
           const sourceLabel = feat.source.name.label;
@@ -133,7 +155,7 @@
         });
     },
     {
-      watch: [searchQuery, categoriesKey, excludeKey],
+      watch: [searchQuery, categoriesKey, excludeKey, sourcesKey],
       dedupe: 'defer',
       lazy: true,
       default: () => [],


### PR DESCRIPTION
Выбор боевого стиля игнорировал глобальную настройку источников и позволял взять один и тот же стиль второй копией через модалку «Черты», а разбор изменений тянул за собой лишние константы и заглушки в таблицах прогрессии.

Источники:

- у `SelectFeat` появился проп `sources`: эндпоинт `/feats/select` по источникам не фильтрует, поэтому отбор идёт на клиенте, как в `filterClassOptionsBySources`; пустой список означает отсутствие ограничения
- ключ и `watch` `useAsyncData` в селекторе учитывают список источников
- проверка «значение уже выбрано» вынесена в `isSelectedUrl`
- фильтры источников классов и черт в визарде класса загружаются параллельно, чтобы открытие не ждало два запроса подряд
- ключ `useAsyncData` источников черт вынесен в `FEAT_SOURCES_ASYNC_DATA_KEY`: кеш фильтров общий у модалки черт и визарда класса

Дубли и типы:

- `getFeatUrlFromFeatureId` распознаёт идентификатор боевого стиля (`class:{featureKey}:fighting-style:{url}`), поэтому модалка «Черты» считает выбранный стиль уже взятой чертой
- `fightingStyleChoice` в `ClassFeature` стало опциональным, как соседние `isSubclass` и `hideInSubclasses`; заглушки `fightingStyleChoice: false` в строках прогрессии `ClassTable` и `MulticlassTable` удалены

Обработка ошибок и подписи:

- `try/catch` в `handleApply` сужен до загрузки черт: применение класса вынесено наружу, поэтому его ошибка больше не выглядит как сбой боевого стиля
- недостижимая ветка «не выбран стиль» удалена — строки без выбора просто не попадают в загрузку, а применение блокирует `isApplyDisabled`
- добавлен тип `FightingStyleSelection` вместо инлайнового описания
- тост заменён локальной `showFightingStyleError` рядом с `showLoadError`, подписи чекбокса в редакторе класса возвращены инлайн — удалены константы `FIGHTING_STYLE_ERROR_*`, `FIGHTING_STYLE_CHOICE_REQUIRED_ERROR` и `CLASS_FEATURE_FIGHTING_STYLE_*`
- у оставшихся констант боевого стиля появились отдельные JSDoc