### PR TITLE
feat(classes): блок стартового снаряжения в редакторе класса

### DIFF
--- a/app/features/classes/editor/ClassEditor.vue
+++ b/app/features/classes/editor/ClassEditor.vue
@@ -14,6 +14,7 @@
     FeaturesEditor,
     MulticlassProficiencySettings,
     ProficiencySettings,
+    StartingEquipmentEditor,
     TableEditor,
   } from './ui';
 
@@ -68,6 +69,7 @@
         skills: 0,
       },
       equipment: undefined,
+      startingEquipment: [],
       features: [],
       table: [],
       abilityTemplate: undefined,
@@ -142,6 +144,8 @@
         </UFormField>
       </div>
     </UCard>
+
+    <StartingEquipmentEditor v-model="state.startingEquipment" />
 
     <UCard variant="subtle">
       <template #header>

--- a/app/features/classes/editor/ui/StartingEquipmentEditor.vue
+++ b/app/features/classes/editor/ui/StartingEquipmentEditor.vue
@@ -1,0 +1,196 @@
+<script setup lang="ts">
+  import type {
+    ClassEquipmentItemCreate,
+    ClassEquipmentOptionCreate,
+  } from '../../model';
+
+  import { EditorArrayControls } from '~ui/editor';
+  import { SelectItem } from '~ui/select';
+
+  import {
+    CLASS_EQUIPMENT_OPTION_LABELS,
+    DEFAULT_CLASS_EQUIPMENT_OPTIONS_COUNT,
+  } from '../../model';
+
+  const state = defineModel<Array<ClassEquipmentOptionCreate>>({
+    required: true,
+  });
+
+  // Класс без снаряжения открывается с двумя пустыми вариантами — «А» и «Б».
+  // Guard по длине разрывает цикл: после наполнения массив уже не пуст,
+  // поэтому повторное присвоение state.value не происходит.
+  watch(
+    state,
+    (options) => {
+      if (options.length) {
+        return;
+      }
+
+      state.value = Array.from(
+        { length: DEFAULT_CLASS_EQUIPMENT_OPTIONS_COUNT },
+        getEmptyEquipmentOption,
+      );
+    },
+    { immediate: true, deep: false },
+  );
+
+  /** Пустой вариант снаряжения: без предметов и без монет. */
+  function getEmptyEquipmentOption(): ClassEquipmentOptionCreate {
+    return { items: [], coins: undefined };
+  }
+
+  /** Пустая строка предмета внутри варианта снаряжения. */
+  function getEmptyEquipmentItem(): ClassEquipmentItemCreate {
+    return { url: undefined, quantity: undefined, description: undefined };
+  }
+
+  /** Добавляет новый пустой вариант снаряжения в конец списка. */
+  function addEmptyEquipmentOption(): void {
+    state.value.push(getEmptyEquipmentOption());
+  }
+
+  /** Удаляет вариант снаряжения вместе со всеми его предметами. */
+  function removeEquipmentOption(optionIndex: number): void {
+    state.value.splice(optionIndex, 1);
+  }
+
+  /** Добавляет пустую строку предмета в указанный вариант снаряжения. */
+  function addEmptyEquipmentItem(option: ClassEquipmentOptionCreate): void {
+    option.items.push(getEmptyEquipmentItem());
+  }
+
+  /** Метка варианта по его порядку: «А», «Б», … — так же, как её выводит API. */
+  function getEquipmentOptionLabel(optionIndex: number): string {
+    return (
+      CLASS_EQUIPMENT_OPTION_LABELS[optionIndex] ?? String(optionIndex + 1)
+    );
+  }
+</script>
+
+<template>
+  <UCard variant="subtle">
+    <template #header>
+      <div class="flex items-center justify-between gap-4">
+        <h2 class="truncate text-base text-highlighted">
+          Варианты стартового снаряжения
+        </h2>
+
+        <UButton
+          icon="tabler:plus"
+          variant="subtle"
+          @click.left.exact.prevent="addEmptyEquipmentOption"
+        >
+          Добавить вариант
+        </UButton>
+      </div>
+    </template>
+
+    <div class="flex flex-col gap-4">
+      <UCard
+        v-for="(option, optionIndex) in state"
+        :key="optionIndex"
+        variant="subtle"
+      >
+        <template #header>
+          <div class="flex items-center justify-between gap-4">
+            <h3 class="truncate text-sm text-highlighted">
+              Вариант {{ getEquipmentOptionLabel(optionIndex) }}
+            </h3>
+
+            <UButton
+              icon="tabler:trash"
+              variant="subtle"
+              color="error"
+              @click.left.exact.prevent="removeEquipmentOption(optionIndex)"
+            >
+              Удалить вариант
+            </UButton>
+          </div>
+        </template>
+
+        <div class="grid grid-cols-1 gap-4 md:grid-cols-24">
+          <UForm
+            v-for="(equipmentItem, itemIndex) in option.items"
+            :key="itemIndex"
+            class="col-span-full grid grid-cols-1 gap-4 md:grid-cols-24"
+            attach
+            :state="equipmentItem"
+          >
+            <UFormField
+              class="col-span-full md:col-span-8"
+              label="Предмет"
+              name="url"
+            >
+              <SelectItem v-model="equipmentItem.url" />
+            </UFormField>
+
+            <UFormField
+              class="col-span-full md:col-span-4"
+              label="Количество"
+              name="quantity"
+            >
+              <UInputNumber
+                v-model="equipmentItem.quantity"
+                placeholder="Введи количество"
+                :min="1"
+              />
+            </UFormField>
+
+            <UFormField
+              class="col-span-full md:col-span-8"
+              label="Уточнение"
+              name="description"
+            >
+              <UInput
+                v-model="equipmentItem.description"
+                placeholder="Например: по вашему выбору"
+              />
+            </UFormField>
+
+            <EditorArrayControls
+              v-model="option.items"
+              :item="equipmentItem"
+              :empty-object="getEmptyEquipmentItem()"
+              :index="itemIndex"
+              cols="4"
+              only-remove
+            />
+          </UForm>
+
+          <div
+            v-if="!option.items.length"
+            class="col-span-full flex justify-center"
+          >
+            <UButton @click.left.exact.prevent="addEmptyEquipmentItem(option)">
+              Добавить предмет
+            </UButton>
+          </div>
+
+          <USeparator class="col-span-full my-2" />
+
+          <UFormField
+            class="col-span-full md:col-span-8"
+            label="Монеты"
+            help="Количество золотых монет варианта"
+            name="coins"
+          >
+            <UInputNumber
+              v-model="option.coins"
+              placeholder="Введи количество"
+              :min="0"
+            />
+          </UFormField>
+        </div>
+      </UCard>
+
+      <div
+        v-if="!state.length"
+        class="grid place-items-center py-2"
+      >
+        <UButton @click.left.exact.prevent="addEmptyEquipmentOption">
+          Добавить вариант
+        </UButton>
+      </div>
+    </div>
+  </UCard>
+</template>

--- a/app/features/classes/editor/ui/index.ts
+++ b/app/features/classes/editor/ui/index.ts
@@ -2,4 +2,5 @@ export { default as CharacteristicsSettings } from './CharacteristicsSettings.vu
 export { default as FeaturesEditor } from './FeaturesEditor.vue';
 export { default as MulticlassProficiencySettings } from './MulticlassProficiencySettings.vue';
 export { default as ProficiencySettings } from './ProficiencySettings.vue';
+export { default as StartingEquipmentEditor } from './StartingEquipmentEditor.vue';
 export { default as TableEditor } from './TableEditor.vue';

--- a/app/features/classes/model/constants.ts
+++ b/app/features/classes/model/constants.ts
@@ -9,6 +9,15 @@ export const CLASS_RESOURCE_RECOVERY_OPTIONS: Array<{
   { label: 'Продолжительный отдых', value: 'LONG_REST' },
 ];
 
+/**
+ * Метки вариантов стартового снаряжения. Выводятся из порядка вариантов —
+ * так же, как их выводит API при отдаче класса, поэтому в форме не хранятся.
+ */
+export const CLASS_EQUIPMENT_OPTION_LABELS = 'АБВГДЕЖЗИКЛМНОПРСТУФХЦЧШЩЭЮЯ';
+
+/** Сколько вариантов снаряжения показывать у класса, где снаряжение ещё не заполнено. */
+export const DEFAULT_CLASS_EQUIPMENT_OPTIONS_COUNT = 2;
+
 /** Подписи настройки выбора боевого стиля в редакторе умения класса. */
 export const CLASS_FEATURE_FIGHTING_STYLE_LABEL = 'Даёт выбор боевого стиля?';
 

--- a/app/features/classes/model/create.ts
+++ b/app/features/classes/model/create.ts
@@ -91,6 +91,22 @@ export interface ClassPrimaryCharacteristicsCreate {
   delimiter: AbilityDelimiter | undefined;
 }
 
+export interface ClassEquipmentItemCreate {
+  url: string | undefined;
+  quantity: number | undefined;
+  description: string | undefined;
+}
+
+export interface ClassEquipmentOptionCreate {
+  items: Array<ClassEquipmentItemCreate>;
+  coins: number | undefined;
+  /**
+   * Тип монет варианта. В редакторе не задаётся — API проставляет золото по умолчанию,
+   * поле нужно, чтобы сохранённое значение не терялось при повторном сохранении.
+   */
+  coin?: string;
+}
+
 export interface ClassCreate extends EditorBaseInfoState {
   gallery: Array<string>;
   description: string | undefined;
@@ -100,6 +116,7 @@ export interface ClassCreate extends EditorBaseInfoState {
   proficiency: ClassProficiencyCreate;
   multiclassProficiency: ClassMulticlassProficiencyCreate;
   equipment: string | undefined;
+  startingEquipment: Array<ClassEquipmentOptionCreate>;
   features: Array<ClassFeatureCreate>;
   table: Array<ClassColumnCreate>;
   casterType: string | undefined;


### PR DESCRIPTION
Редактор класса получил блок вариантов снаряжения: подблоки можно добавлять и удалять, по умолчанию их два — «А» и «Б». Внутри подблока список предметов с количеством и текстовым уточнением плюс количество монет. Прежнее markdown-поле снаряжения осталось на месте.

Метки вариантов выводятся из порядка, названия предметов не отправляются — их подставляет API из справочника.