### PR TITLE
fix(spells): цель части урона не подставляется в формулу

### DIFF
--- a/app/features/spells/editor/ui/SpellDamageFormulas.vue
+++ b/app/features/spells/editor/ui/SpellDamageFormulas.vue
@@ -1,4 +1,9 @@
 <script setup lang="ts">
+  import type {
+    SpellDamageFormulaPart,
+    SpellDamageFormulaTarget,
+  } from '../../model';
+
   import { isEqual } from 'es-toolkit';
 
   import { DictionaryService } from '~/shared/api';
@@ -6,9 +11,10 @@
   import {
     appendSpellDamageFormulaModifier,
     appendSpellDamageFormulaTag,
-    DEFAULT_SPELL_DAMAGE_FORMULA_TARGET,
+    createEmptySpellDamageFormulaPart,
     DEFAULT_SPELL_DAMAGE_FORMULA_TOOL,
     incrementSpellDamageFormulaDice,
+    isSpellDamageFormulaTarget,
     SPELL_DAMAGE_FORMULA_CONDITION_TAGS,
     SPELL_DAMAGE_FORMULA_DICE,
     SPELL_DAMAGE_FORMULA_HEALING_TAGS,
@@ -18,10 +24,12 @@
     SPELL_DAMAGE_TYPE_TAGS,
   } from '../../model';
 
-  const DAMAGE_TARGET_TAG_PATTERN = /@target\.(self|separate)\b/g;
+  const model = defineModel<Array<SpellDamageFormulaPart>>({ required: true });
 
-  const model = defineModel<Array<string>>({ required: true });
-  const formulaRows = ref<Array<string>>(['']);
+  const formulaRows = ref<Array<SpellDamageFormulaPart>>([
+    createEmptySpellDamageFormulaPart(),
+  ]);
+
   const activeToolByRow = ref<Record<number, string>>({});
 
   const { data: damageTypes, status } = await useAsyncData(
@@ -32,22 +40,28 @@
 
   const damageTypeItems = computed(() => damageTypes.value ?? []);
 
-  function normalizeFormulaRows(rows: Array<string>): Array<string> {
-    return rows.map((row) => row.trim()).filter(Boolean);
+  function normalizeFormulaRows(
+    rows: Array<SpellDamageFormulaPart>,
+  ): Array<SpellDamageFormulaPart> {
+    return rows
+      .map((row) => ({ ...row, formula: row.formula.trim() }))
+      .filter((row) => row.formula);
   }
 
   watch(
     model,
-    (damageFormulas) => {
+    (damageFormulaParts) => {
       const normalizedRows = normalizeFormulaRows(formulaRows.value);
 
       // Цикл синхронизации завершается здесь: пустые локальные строки нужны только UI,
       // а модель хранит только непустые формулы.
-      if (isEqual(normalizedRows, damageFormulas)) {
+      if (isEqual(normalizedRows, damageFormulaParts)) {
         return;
       }
 
-      formulaRows.value = damageFormulas.length ? [...damageFormulas] : [''];
+      formulaRows.value = damageFormulaParts.length
+        ? damageFormulaParts.map((part) => ({ ...part }))
+        : [createEmptySpellDamageFormulaPart()];
     },
     { immediate: true },
   );
@@ -60,8 +74,11 @@
     return activeToolByRow.value[rowIndex] ?? DEFAULT_SPELL_DAMAGE_FORMULA_TOOL;
   }
 
-  function saveFormulaRows(rows: Array<string>): void {
-    formulaRows.value = rows.length ? rows : [''];
+  function saveFormulaRows(rows: Array<SpellDamageFormulaPart>): void {
+    formulaRows.value = rows.length
+      ? rows
+      : [createEmptySpellDamageFormulaPart()];
+
     model.value = normalizeFormulaRows(rows);
   }
 
@@ -70,9 +87,9 @@
     updateFormula: (formula: string) => string,
   ): void {
     const rows = [...formulaRows.value];
-    const formula = rows[rowIndex] ?? '';
+    const row = rows[rowIndex] ?? createEmptySpellDamageFormulaPart();
 
-    rows[rowIndex] = updateFormula(formula);
+    rows[rowIndex] = { ...row, formula: updateFormula(row.formula) };
     saveFormulaRows(rows);
   }
 
@@ -84,31 +101,18 @@
     updateFormula(rowIndex, typeof modelValue === 'string' ? modelValue : '');
   }
 
-  function getDamageTarget(formula: string): string {
-    if (formula.includes('@target.self')) {
-      return 'target.self';
-    }
-
-    if (formula.includes('@target.separate')) {
-      return 'target.separate';
-    }
-
-    return DEFAULT_SPELL_DAMAGE_FORMULA_TARGET;
-  }
-
-  function updateDamageTarget(rowIndex: number, target: string): void {
+  /**
+   * Меняет цель части урона. В формулу цель не пишется: VTTG понимает в ней
+   * только теги `@target.full`/`@target.notFull`, а сама цель — отдельное поле.
+   */
+  function updateDamageTarget(
+    rowIndex: number,
+    target: SpellDamageFormulaTarget,
+  ): void {
     const rows = [...formulaRows.value];
-    const formula = rows[rowIndex] ?? '';
+    const row = rows[rowIndex] ?? createEmptySpellDamageFormulaPart();
 
-    const formulaWithoutTarget = formula
-      .replace(DAMAGE_TARGET_TAG_PATTERN, '')
-      .trim();
-
-    rows[rowIndex] =
-      target === DEFAULT_SPELL_DAMAGE_FORMULA_TARGET
-        ? formulaWithoutTarget
-        : `${formulaWithoutTarget}@${target}`.trim();
-
+    rows[rowIndex] = { ...row, target };
     saveFormulaRows(rows);
   }
 
@@ -116,7 +120,7 @@
     rowIndex: number,
     modelValue: unknown,
   ): void {
-    if (typeof modelValue !== 'string') {
+    if (!isSpellDamageFormulaTarget(modelValue)) {
       return;
     }
 
@@ -148,14 +152,14 @@
   function addFormula(rowIndex: number): void {
     const rows = [...formulaRows.value];
 
-    rows.splice(rowIndex + 1, 0, '');
+    rows.splice(rowIndex + 1, 0, createEmptySpellDamageFormulaPart());
     saveFormulaRows(rows);
   }
 
   function clearFormula(rowIndex: number): void {
     const rows = [...formulaRows.value];
 
-    rows[rowIndex] = '';
+    rows[rowIndex] = createEmptySpellDamageFormulaPart();
     saveFormulaRows(rows);
   }
 
@@ -181,7 +185,7 @@
 <template>
   <div class="col-span-full grid gap-3">
     <UFormField
-      v-for="(formula, rowIndex) in formulaRows"
+      v-for="(row, rowIndex) in formulaRows"
       :key="rowIndex"
       :label="`Урон, часть ${rowIndex + 1}`"
       :name="`effect.damageFormulas.${rowIndex}`"
@@ -189,7 +193,7 @@
       <div class="rounded-lg border border-default bg-muted p-3">
         <div class="flex flex-col gap-3">
           <UInput
-            :model-value="formula"
+            :model-value="row.formula"
             placeholder="Например: 8d6@dmg.fire"
             @update:model-value="handleFormulaInput(rowIndex, $event)"
           />
@@ -284,7 +288,7 @@
             :name="`effect.damageFormulaTargets.${rowIndex}`"
           >
             <USelect
-              :model-value="getDamageTarget(formula)"
+              :model-value="row.target"
               :items="SPELL_DAMAGE_FORMULA_TARGET_OPTIONS"
               @update:model-value="handleDamageTargetInput(rowIndex, $event)"
             />
@@ -306,7 +310,7 @@
               size="xs"
               variant="subtle"
               color="error"
-              :disabled="!formula"
+              :disabled="!row.formula"
               @click.left.exact.prevent="clearFormula(rowIndex)"
             >
               Очистить

--- a/app/features/spells/editor/ui/SpellEffectEditor.vue
+++ b/app/features/spells/editor/ui/SpellEffectEditor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import type { SpellEffect } from '../../model';
+  import type { SpellDamageFormulaPart, SpellEffect } from '../../model';
 
   import {
     SelectAbilities,
@@ -9,6 +9,8 @@
   } from '~ui/select';
 
   import {
+    applySpellDamageFormulaParts,
+    getSpellDamageFormulaParts,
     SPELL_SAVE_EFFECT_OPTIONS,
     SPELL_TARGET_TYPE_OPTIONS,
   } from '../../model';
@@ -21,13 +23,13 @@
 
   const model = defineModel<SpellEffect>({ required: true });
 
-  const damageFormulas = computed<Array<string>>({
-    get: () => model.value.damageFormulas ?? [],
+  // Формулы и их цели хранятся двумя параллельными массивами, но редактируются
+  // как один список частей — иначе два отдельных обновления модели разъезжаются
+  // по индексам.
+  const damageFormulaParts = computed<Array<SpellDamageFormulaPart>>({
+    get: () => getSpellDamageFormulaParts(model.value),
     set: (value) => {
-      model.value = {
-        ...model.value,
-        damageFormulas: value,
-      };
+      model.value = applySpellDamageFormulaParts(model.value, value);
     },
   });
 
@@ -151,7 +153,7 @@
         :hint="projectileHint"
       />
 
-      <SpellDamageFormulas v-model="damageFormulas" />
+      <SpellDamageFormulas v-model="damageFormulaParts" />
 
       <!-- Спасброски -->
       <UFormField

--- a/app/features/spells/model/constants.ts
+++ b/app/features/spells/model/constants.ts
@@ -1,4 +1,8 @@
-import type { SpellSaveEffect, SpellTargetType } from './create';
+import type {
+  SpellDamageFormulaTarget,
+  SpellSaveEffect,
+  SpellTargetType,
+} from './create';
 
 interface SpellSelectOption<Value extends string> {
   label: string;
@@ -103,10 +107,16 @@ export const SPELL_DAMAGE_FORMULA_MODIFIER_TAGS = [
   { label: 'Уровень', value: 'level' },
 ];
 
-export const SPELL_DAMAGE_FORMULA_TARGET_OPTIONS = [
+/**
+ * Цель части урона. Значения — словарь VTTG (`DamagePartTarget`); в формулу
+ * они не пишутся, а хранятся в `SpellEffect.damageFormulaTargets`.
+ */
+export const SPELL_DAMAGE_FORMULA_TARGET_OPTIONS: Array<
+  SpellSelectOption<SpellDamageFormulaTarget>
+> = [
   { label: 'Выбранная цель', value: 'selected' },
-  { label: 'На себя', value: 'target.self' },
-  { label: 'Указать отдельно', value: 'target.separate' },
+  { label: 'На себя', value: 'self' },
+  { label: 'Указать отдельно', value: 'choose' },
 ];
 
 export const SPELL_DAMAGE_FORMULA_TOOLS = [
@@ -118,4 +128,5 @@ export const SPELL_DAMAGE_FORMULA_TOOLS = [
 ];
 
 export const DEFAULT_SPELL_DAMAGE_FORMULA_TOOL = 'modifier';
-export const DEFAULT_SPELL_DAMAGE_FORMULA_TARGET = 'selected';
+export const DEFAULT_SPELL_DAMAGE_FORMULA_TARGET: SpellDamageFormulaTarget =
+  'selected';

--- a/app/features/spells/model/create.ts
+++ b/app/features/spells/model/create.ts
@@ -4,7 +4,12 @@ import type { EditorBaseInfoState } from '~ui/editor';
 
 import { normalizeLoadedActiveEffects } from '~active-effects/model';
 
-import { SPELL_DAMAGE_TYPE_TAGS, SPELL_HEALING_TYPE_TAGS } from './constants';
+import {
+  DEFAULT_SPELL_DAMAGE_FORMULA_TARGET,
+  SPELL_DAMAGE_FORMULA_TARGET_OPTIONS,
+  SPELL_DAMAGE_TYPE_TAGS,
+  SPELL_HEALING_TYPE_TAGS,
+} from './constants';
 
 /**
  * Тип цели заклинания.
@@ -34,6 +39,23 @@ export interface SpellAreaOfEffect {
  * Зеркало `SpellProjectiles.targetDistribution` из VTTG.
  */
 export type SpellProjectileDistribution = 'any' | 'single' | 'distinct';
+
+/**
+ * Цель части урона/лечения. Зеркало `DamagePartTarget` из VTTG:
+ * `selected` — выбранная цель (дефолт), `self` — заклинатель,
+ * `choose` — отдельная цель, указывается перед броском.
+ */
+export type SpellDamageFormulaTarget = 'selected' | 'self' | 'choose';
+
+/**
+ * Часть урона в редакторе: формула и её цель. В `SpellEffect` хранится двумя
+ * параллельными массивами (`damageFormulas` + `damageFormulaTargets`), потому
+ * что справочник отдаёт формулы плоским списком строк.
+ */
+export interface SpellDamageFormulaPart {
+  formula: string;
+  target: SpellDamageFormulaTarget;
+}
 
 /**
  * Порог уровня персонажа → полное число снарядов (для заговоров).
@@ -69,6 +91,7 @@ export interface SpellEffect {
   autoHit?: boolean;
   projectiles?: SpellProjectiles;
   damageFormulas?: string[];
+  damageFormulaTargets?: SpellDamageFormulaTarget[]; // цели частей урона, по индексам damageFormulas
   damageFormula?: string;
   damageTypes?: string[];
   healingTypes?: string[];
@@ -152,6 +175,7 @@ export function createEmptySpellEffect(): SpellEffect {
     autoHit: false,
     projectiles: undefined,
     damageFormulas: [],
+    damageFormulaTargets: [],
     damageFormula: undefined,
     damageTypes: [],
     healingTypes: [],
@@ -274,6 +298,133 @@ function migrateSpellEffectHealingFormulas(effect: SpellEffect): SpellEffect {
 }
 
 /**
+ * Legacy-теги цели, которые редактор писал прямо в формулу урона. Ни один
+ * потребитель их не понимает: VTTG знает только `@target.full`/`@target.notFull`,
+ * а лист персонажа выбрасывает формулу с незнакомым тегом целиком.
+ */
+const LEGACY_DAMAGE_TARGET_TAGS: Array<{
+  tag: string;
+  target: SpellDamageFormulaTarget;
+}> = [
+  { tag: '@target.self', target: 'self' },
+  { tag: '@target.separate', target: 'choose' },
+];
+
+const LEGACY_DAMAGE_TARGET_TAG_PATTERN = /@target\.(?:self|separate)\b/g;
+
+/**
+ * Проверяет, что значение — цель части урона из словаря VTTG.
+ */
+export function isSpellDamageFormulaTarget(
+  value: unknown,
+): value is SpellDamageFormulaTarget {
+  return SPELL_DAMAGE_FORMULA_TARGET_OPTIONS.some(
+    (option) => option.value === value,
+  );
+}
+
+/**
+ * Создаёт пустую часть урона для редактора.
+ */
+export function createEmptySpellDamageFormulaPart(): SpellDamageFormulaPart {
+  return {
+    formula: '',
+    target: DEFAULT_SPELL_DAMAGE_FORMULA_TARGET,
+  };
+}
+
+/**
+ * Собирает части урона редактора из параллельных массивов SpellEffect.
+ *
+ * @param effect воздействие заклинания.
+ * @returns части урона в порядке формул; цель без пары — `selected`.
+ */
+export function getSpellDamageFormulaParts(
+  effect: SpellEffect,
+): SpellDamageFormulaPart[] {
+  const damageFormulaTargets = effect.damageFormulaTargets ?? [];
+
+  return (effect.damageFormulas ?? []).map((formula, index) => ({
+    formula,
+    target: damageFormulaTargets[index] ?? DEFAULT_SPELL_DAMAGE_FORMULA_TARGET,
+  }));
+}
+
+/**
+ * Раскладывает части урона редактора обратно в параллельные массивы
+ * SpellEffect одним обновлением — иначе формулы и цели разъезжаются по индексам.
+ *
+ * @param effect воздействие заклинания.
+ * @param parts части урона из редактора.
+ * @returns новое воздействие с обновлёнными формулами и целями.
+ */
+export function applySpellDamageFormulaParts(
+  effect: SpellEffect,
+  parts: SpellDamageFormulaPart[],
+): SpellEffect {
+  return {
+    ...effect,
+    damageFormulas: parts.map((part) => part.formula),
+    damageFormulaTargets: parts.map((part) => part.target),
+  };
+}
+
+/**
+ * Восстанавливает цели частей урона из загруженного с сервера raw-значения.
+ * Незнакомое значение заменяется дефолтом, чтобы не сбить выравнивание по
+ * индексам формул.
+ */
+function normalizeLoadedSpellDamageFormulaTargets(
+  raw: unknown,
+): SpellDamageFormulaTarget[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  // Array.isArray сужает unknown до any[], поэтому элементы читаются через
+  // явно типизированный unknown-массив.
+  const rawTargets: Array<unknown> = raw;
+
+  return rawTargets.map((target) =>
+    isSpellDamageFormulaTarget(target)
+      ? target
+      : DEFAULT_SPELL_DAMAGE_FORMULA_TARGET,
+  );
+}
+
+/**
+ * Возвращает цель, зашитую legacy-тегом в формулу урона.
+ */
+function getLegacyDamageFormulaTarget(
+  formula: string,
+): SpellDamageFormulaTarget | undefined {
+  return LEGACY_DAMAGE_TARGET_TAGS.find(({ tag }) => formula.includes(tag))
+    ?.target;
+}
+
+/**
+ * Мигрирует legacy-теги цели из формул урона в отдельное поле
+ * `damageFormulaTargets` и выравнивает его по длине списка формул.
+ */
+function migrateSpellEffectDamageTargets(effect: SpellEffect): SpellEffect {
+  const damageFormulas = effect.damageFormulas ?? [];
+  const damageFormulaTargets = effect.damageFormulaTargets ?? [];
+
+  return {
+    ...effect,
+    damageFormulas: damageFormulas.map((formula) =>
+      formula.replace(LEGACY_DAMAGE_TARGET_TAG_PATTERN, '').trim(),
+    ),
+    damageFormulaTargets: damageFormulas.map(
+      (formula, index) =>
+        getLegacyDamageFormulaTarget(formula)
+        ?? damageFormulaTargets[index]
+        ?? DEFAULT_SPELL_DAMAGE_FORMULA_TARGET,
+    ),
+  };
+}
+
+/**
  * Мигрирует старые формулы урона SpellEffect к новому формату массивов формул.
  */
 function migrateSpellEffectDamageFormulas(effect: SpellEffect): SpellEffect {
@@ -311,8 +462,8 @@ function migrateSpellEffectDamageFormulas(effect: SpellEffect): SpellEffect {
 export function normalizeSpellEffect(
   effect: SpellEffect,
 ): SpellEffect | undefined {
-  const migratedEffect = migrateSpellEffectHealingFormulas(
-    migrateSpellEffectDamageFormulas(effect),
+  const migratedEffect = migrateSpellEffectDamageTargets(
+    migrateSpellEffectHealingFormulas(migrateSpellEffectDamageFormulas(effect)),
   );
 
   const normalized: SpellEffect = {};
@@ -365,6 +516,18 @@ export function normalizeSpellEffect(
     && migratedEffect.damageFormulas.length > 0
   ) {
     normalized.damageFormulas = migratedEffect.damageFormulas;
+
+    const damageFormulaTargets = migratedEffect.damageFormulaTargets ?? [];
+
+    // Цели пишутся, только если хоть одна часть уходит не в выбранную цель:
+    // `selected` — дефолт VTTG, хранить его в справочнике незачем.
+    const hasCustomTarget = damageFormulaTargets.some(
+      (target) => target !== DEFAULT_SPELL_DAMAGE_FORMULA_TARGET,
+    );
+
+    if (hasCustomTarget) {
+      normalized.damageFormulaTargets = damageFormulaTargets;
+    }
   }
 
   if (migratedEffect.savingThrows && migratedEffect.savingThrows.length > 0) {
@@ -463,21 +626,26 @@ export function normalizeLoadedSpell(
   if (result.effect && isRecord(result.effect)) {
     const rawEffect = result.effect;
 
-    result.effect = migrateSpellEffectHealingFormulas(
-      migrateSpellEffectDamageFormulas({
-        ...createEmptySpellEffect(),
-        ...rawEffect,
-        areaOfEffect:
-          rawEffect.areaOfEffect && isRecord(rawEffect.areaOfEffect)
-            ? {
-                type: undefined,
-                value1: undefined,
-                value2: undefined,
-                ...rawEffect.areaOfEffect,
-              }
-            : createEmptySpellEffect().areaOfEffect,
-        projectiles: normalizeLoadedSpellProjectiles(rawEffect.projectiles),
-      }),
+    result.effect = migrateSpellEffectDamageTargets(
+      migrateSpellEffectHealingFormulas(
+        migrateSpellEffectDamageFormulas({
+          ...createEmptySpellEffect(),
+          ...rawEffect,
+          damageFormulaTargets: normalizeLoadedSpellDamageFormulaTargets(
+            rawEffect.damageFormulaTargets,
+          ),
+          areaOfEffect:
+            rawEffect.areaOfEffect && isRecord(rawEffect.areaOfEffect)
+              ? {
+                  type: undefined,
+                  value1: undefined,
+                  value2: undefined,
+                  ...rawEffect.areaOfEffect,
+                }
+              : createEmptySpellEffect().areaOfEffect,
+          projectiles: normalizeLoadedSpellProjectiles(rawEffect.projectiles),
+        }),
+      ),
     );
   } else {
     // Миграция старых записей без effect


### PR DESCRIPTION
Селект «Цель» писал в формулу теги @target.self/@target.separate, которых не понимает ни один потребитель: VTTG знает в формуле только @target.full/@target.notFull, а лист персонажа выбрасывал формулу с незнакомым тегом целиком.

Цель переехала в отдельное поле effect.damageFormulaTargets (словарь VTTG: selected/self/choose), выровненное по индексам damageFormulas. Формулы и цели редактируются одним списком частей, чтобы два раздельных обновления модели не разъезжались по индексам. Старые формулы с legacy-тегами мигрируются при загрузке заклинания в редактор.