### PR TITLE
feat(character-sheet): учёт источника владений и владения от черт

### DIFF
--- a/app/features/character-sheet/composables/useCharacterSheet.ts
+++ b/app/features/character-sheet/composables/useCharacterSheet.ts
@@ -18,6 +18,7 @@ import type {
   CharacterNote,
   CharacterPersonality,
   CharacterPreparedSpells,
+  CharacterProficiencies,
   CharacterSavingThrow,
   CharacterSettings,
   CharacterSkill,
@@ -28,11 +29,13 @@ import type {
   CharacterVision,
   CustomInventoryItemDraft,
   CustomSpellDraft,
+  GrantedProficiencies,
   HitDiceAmount,
   LevelUpHitPointsGain,
   LevelUpPayload,
   PlainProficiencyGroupKey,
   PreparedSpellKind,
+  ProficiencyGrant,
   SpellSlotKind,
   StartingEquipmentGrant,
 } from '../model';
@@ -47,6 +50,7 @@ import {
   adjustHitDice,
   applyAbilityIncreases,
   applyLevelHitPoints,
+  applyProficiencyGrants,
   applySkillProficiencies,
   applyStartingEquipmentChange,
   ARMOR_CLASS_BASE_MAX,
@@ -87,6 +91,7 @@ import {
   getInventoryWeight,
   getNextLevelExperience,
   getPreparedSpellsLimitDescription,
+  getProficiencySourceId,
   getSavingThrowRows,
   getSkillRowGroups,
   getSkillRows,
@@ -118,6 +123,7 @@ import {
   PREPARED_SPELLS_BONUS_MIN,
   PREPARED_SPELLS_MAX,
   PREPARED_SPELLS_MIN,
+  pruneProficiencyGrants,
   removeClassFeatures,
   removeClassResources,
   removeFeaturesAboveLevel,
@@ -144,10 +150,10 @@ import {
   toStoredSettings,
   toTrimmedPersonality,
   toUpdatedCustomInventoryItem,
-  unionToolProficiencies,
   VISION_DISTANCE_MAX,
   VISION_DISTANCE_MIN,
   withFeatModifiers,
+  withProficiencyGrant,
   withSavingThrowProficiencies,
 } from '../model';
 
@@ -848,6 +854,40 @@ export function useCharacterSheet() {
   }
 
   /**
+   * Владения и журнал выдач после смены источника: запись прежнего источника
+   * уходит, запись нового ложится поверх, а список владений приводится к новому
+   * журналу — выданное прежним источником снимается, если его не даёт больше
+   * никто.
+   *
+   * @param previousSource идентификатор прежнего источника; null — его не было.
+   * @param source идентификатор нового источника.
+   * @param granted выданные владения; null — источник ничего не выдаёт.
+   * @returns владения и журнал выдач листа.
+   */
+  function withSourceProficiencies(
+    previousSource: string | null,
+    source: string,
+    granted: GrantedProficiencies | null,
+  ): { proficiencies: CharacterProficiencies; grants: ProficiencyGrant[] } {
+    const previousGrants = character.value.proficiencyGrants;
+
+    const withoutPrevious = previousSource
+      ? withProficiencyGrant(previousGrants, previousSource, null)
+      : previousGrants;
+
+    const grants = withProficiencyGrant(withoutPrevious, source, granted);
+
+    return {
+      proficiencies: applyProficiencyGrants(
+        character.value.proficiencies,
+        previousGrants,
+        grants,
+      ),
+      grants,
+    };
+  }
+
+  /**
    * Установка уровней классов и суммарного опыта без мастера подготовки:
    * «Пропустить подготовку» и понижение уровня. Умения и счётчики новых уровней
    * при этом не выдаются — их добавит повторный выбор класса или следующее
@@ -980,6 +1020,10 @@ export function useCharacterSheet() {
           payload.skills.proficient,
           payload.skills.expertise,
         ),
+        // Языки, выбранные в умениях новых уровней, в журнал выдач не идут:
+        // мастер собирает их со всех классов разом и не говорит, чей это выбор,
+        // а без источника запись бессмысленна. Такой язык остаётся на листе
+        // навсегда — как было и до появления журнала.
         proficiencies: {
           ...withLevels.proficiencies,
           languages: union(
@@ -1335,6 +1379,20 @@ export function useCharacterSheet() {
       return;
     }
 
+    // Языки вида — его выдача: смена вида забирает прежние и выдаёт новые.
+    const speciesProficiencies = withSourceProficiencies(
+      character.value.species
+        ? getProficiencySourceId('species', character.value.species.url)
+        : null,
+      getProficiencySourceId('species', payload.species.url),
+      {
+        armor: [],
+        weapons: [],
+        tools: [],
+        languages: payload.proficiencies.languages,
+      },
+    );
+
     // Смена вида заменяет только особенности вида и подвида; добавленные
     // вручную (класс, без источника) сохраняются. Сверка черт (`withFeatModifiers`)
     // здесь не нужна: черты остаются нетронутыми, а снимка механики у умений
@@ -1358,13 +1416,8 @@ export function useCharacterSheet() {
         values: { ...payload.speed.values },
       },
       vision: { ...payload.vision },
-      proficiencies: {
-        ...character.value.proficiencies,
-        languages: union(
-          character.value.proficiencies.languages,
-          payload.proficiencies.languages,
-        ),
-      },
+      proficiencies: speciesProficiencies.proficiencies,
+      proficiencyGrants: speciesProficiencies.grants,
       skills: applySkillProficiencies(
         character.value.skills,
         payload.skills.proficient,
@@ -1486,6 +1539,20 @@ export function useCharacterSheet() {
       characterClass.url,
     );
 
+    // Владения класса — то же, что и его снаряжение: выданное прошлым выбором
+    // снимается, выданное новым ложится поверх. Отмеченное игроком вручную в
+    // журнале выдач не числится и потому не трогается.
+    const classProficiencies = withSourceProficiencies(
+      previousClass ? getProficiencySourceId('class', previousClass.url) : null,
+      getProficiencySourceId('class', characterClass.url),
+      {
+        armor: payload.proficiencies.armor,
+        weapons: payload.proficiencies.weapons,
+        tools: payload.proficiencies.tools,
+        languages: payload.proficiencies.languages,
+      },
+    );
+
     // Инвентарь класс не переписывает: снимается ровно выданный прошлым выбором
     // набор, поверх ложится новый. Купленное игроком остаётся на месте.
     const startingEquipment = applyStartingEquipmentChange(
@@ -1538,25 +1605,8 @@ export function useCharacterSheet() {
           current: maxHitPoints,
           levelGains,
         },
-        proficiencies: {
-          ...character.value.proficiencies,
-          armor: union(
-            character.value.proficiencies.armor,
-            payload.proficiencies.armor,
-          ),
-          weapons: union(
-            character.value.proficiencies.weapons,
-            payload.proficiencies.weapons,
-          ),
-          tools: unionToolProficiencies(
-            character.value.proficiencies.tools,
-            payload.proficiencies.tools,
-          ),
-          languages: union(
-            character.value.proficiencies.languages,
-            payload.proficiencies.languages,
-          ),
-        },
+        proficiencies: classProficiencies.proficiencies,
+        proficiencyGrants: classProficiencies.grants,
         skills: applySkillProficiencies(
           character.value.skills,
           payload.skills.proficient,
@@ -1639,6 +1689,14 @@ export function useCharacterSheet() {
       false,
     ).map((gain) => ({ classUrl: characterClass.url, amount: gain.amount }));
 
+    // Второй класс урезанного набора владений не отдаёт (правило 2024) — из
+    // него в лист идут только выбранные в умениях языки.
+    const addedClassProficiencies = withSourceProficiencies(
+      null,
+      getProficiencySourceId('class', characterClass.url),
+      { armor: [], weapons: [], tools: [], languages: payload.languages },
+    );
+
     const withLevels = withClassLevels(
       { [characterClass.url]: level },
       character.value.experience.current,
@@ -1659,13 +1717,8 @@ export function useCharacterSheet() {
           payload.skills.proficient,
           payload.skills.expertise,
         ),
-        proficiencies: {
-          ...withLevels.proficiencies,
-          languages: union(
-            withLevels.proficiencies.languages,
-            payload.languages,
-          ),
-        },
+        proficiencies: addedClassProficiencies.proficiencies,
+        proficiencyGrants: addedClassProficiencies.grants,
         classResources: [
           ...withLevels.classResources,
           ...payload.classResources,
@@ -1725,6 +1778,15 @@ export function useCharacterSheet() {
 
     const level = getTotalClassLevel(remainingClasses);
 
+    // Владения, выданные этим классом, уходят вместе с ним — если те же не даёт
+    // кто-то ещё. Отмеченного игроком вручную это не касается: его в журнале
+    // выдач нет.
+    const removedClassProficiencies = withSourceProficiencies(
+      null,
+      getProficiencySourceId('class', classUrl),
+      null,
+    );
+
     // Вместе с классом уходят и его черты за улучшение характеристик, а общий
     // уровень падает — прибавка черт к максимуму хитов сверяется по обоим.
     character.value = withFeatModifiers(
@@ -1748,6 +1810,8 @@ export function useCharacterSheet() {
           character.value.classResources,
           classUrl,
         ),
+        proficiencies: removedClassProficiencies.proficiencies,
+        proficiencyGrants: removedClassProficiencies.grants,
       },
       character.value,
     );
@@ -1813,6 +1877,15 @@ export function useCharacterSheet() {
       (feature) => feature.id !== previousFeatId && feature.id !== newFeatId,
     );
 
+    // Инструменты предыстории — её выдача: смена предыстории забирает прежние и
+    // выдаёт новые. Навыки в журнал не идут — они живут не в списке владений, а
+    // отдельными записями с уровнем владения.
+    const backgroundProficiencies = withSourceProficiencies(
+      previous ? getProficiencySourceId('background', previous.url) : null,
+      getProficiencySourceId('background', payload.background.url),
+      { armor: [], weapons: [], tools: payload.tools, languages: [] },
+    );
+
     // Как и у класса: снимается ровно выданный прошлой предысторией набор,
     // поверх ложится новый — купленное игроком не трогается.
     const startingEquipment = applyStartingEquipmentChange(
@@ -1844,13 +1917,8 @@ export function useCharacterSheet() {
           character.value.abilities.constitution,
           abilities.constitution,
         ),
-        proficiencies: {
-          ...character.value.proficiencies,
-          tools: unionToolProficiencies(
-            character.value.proficiencies.tools,
-            payload.tools,
-          ),
-        },
+        proficiencies: backgroundProficiencies.proficiencies,
+        proficiencyGrants: backgroundProficiencies.grants,
         skills: applySkillProficiencies(
           character.value.skills,
           payload.skills,
@@ -2970,12 +3038,20 @@ export function useCharacterSheet() {
       return;
     }
 
+    const proficiencies = {
+      ...character.value.proficiencies,
+      [group]: [...items],
+    };
+
     character.value = {
       ...character.value,
-      proficiencies: {
-        ...character.value.proficiencies,
-        [group]: [...items],
-      },
+      proficiencies,
+      // Снятое игроком уходит и из журнала: иначе сверка вернула бы владение
+      // при ближайшей смене класса или черты.
+      proficiencyGrants: pruneProficiencyGrants(
+        character.value.proficiencyGrants,
+        proficiencies,
+      ),
     };
   }
 
@@ -2990,12 +3066,19 @@ export function useCharacterSheet() {
       return;
     }
 
+    const proficiencies = {
+      ...character.value.proficiencies,
+      tools: tools.map((tool) => ({ ...tool })),
+    };
+
     character.value = {
       ...character.value,
-      proficiencies: {
-        ...character.value.proficiencies,
-        tools: tools.map((tool) => ({ ...tool })),
-      },
+      proficiencies,
+      // Как и у прочих групп: снятый игроком инструмент уходит и из журнала.
+      proficiencyGrants: pruneProficiencyGrants(
+        character.value.proficiencyGrants,
+        proficiencies,
+      ),
     };
   }
 

--- a/app/features/character-sheet/model/character-schema.ts
+++ b/app/features/character-sheet/model/character-schema.ts
@@ -157,6 +157,39 @@ const characterBackgroundSchema = z
   .nullable()
   .catch(null);
 
+// Листы до появления ссылок на инструменты хранят владения строками: такая
+// запись читается без ссылки, а url подставится при следующей правке владений.
+const toolProficiencySchema = z.union([
+  z.string().transform((name) => ({ name, url: null })),
+  z.object({
+    name: z.string().catch(''),
+    url: z.string().nullable().catch(null),
+  }),
+]);
+
+/**
+ * Набор выданных владений. Отдельная схема на два случая: журнал выдач листа и
+ * снимок владений на записи черты.
+ */
+const grantedProficienciesSchema = z.object({
+  armor: z.array(z.string()).catch([]),
+  weapons: z.array(z.string()).catch([]),
+  tools: z.array(toolProficiencySchema).catch([]),
+  languages: z.array(z.string()).catch([]),
+});
+
+/**
+ * Снимок владений, выдаваемых чертой, в записи умения.
+ *
+ * Схема только для документа листа — в отличие от механики, одной на оба
+ * случая: справочник отдаёт владения категориями (`MATERIAL_MELEE`), а лист
+ * хранит записями своего справочника («Всё воинское оружие»), и перевод между
+ * ними делает разбор детали черты в `schemas.ts`.
+ */
+const featProficienciesSchema = grantedProficienciesSchema
+  .nullable()
+  .catch(null);
+
 /** Необязательное число снимка механики: чужое значение просто пропадает. */
 const modifierNumberSchema = z.coerce.number().optional().catch(undefined);
 
@@ -239,6 +272,8 @@ const featureSchema = z.object({
   // Снимок механики черты; у записей до её появления поля нет — такая черта
   // лист не двигает, пока её не добавят заново.
   modifiers: featModifiersSchema,
+  // Снимок выдаваемых чертой владений; у записей до его появления поля нет.
+  proficiencies: featProficienciesSchema,
 });
 
 // Поля своих заклинаний (`custom:<uuid>`) отсутствуют у записей из каталога,
@@ -633,16 +668,6 @@ const classResourceSchema = z
     longRest: toResourceRecoveryRule(longRest, recovery, false),
   }));
 
-// Листы до появления ссылок на инструменты хранят владения строками: такая
-// запись читается без ссылки, а url подставится при следующей правке владений.
-const toolProficiencySchema = z.union([
-  z.string().transform((name) => ({ name, url: null })),
-  z.object({
-    name: z.string().catch(''),
-    url: z.string().nullable().catch(null),
-  }),
-]);
-
 const proficienciesSchema = z
   .object({
     armor: z.array(z.string()).catch([]),
@@ -652,6 +677,24 @@ const proficienciesSchema = z
     languages: z.array(z.string()).catch([]),
   })
   .catch(() => structuredClone(DEFAULT_CHARACTER.proficiencies));
+
+/**
+ * Журнал выдач владений. У листов, сохранённых до его появления, поля нет:
+ * пустой журнал означает, что все владения отмечены вручную и снятие источника
+ * их не трогает — ровно прежнее поведение листа.
+ *
+ * Запись без источника бессмысленна (снять по ней нечего), поэтому `source`
+ * обязателен, а битая запись выпадает поодиночке.
+ */
+const proficiencyGrantsSchema = z
+  .array(
+    grantedProficienciesSchema
+      .extend({ source: z.string() })
+      .nullable()
+      .catch(null),
+  )
+  .catch([])
+  .transform((grants) => grants.filter((grant) => grant !== null));
 
 const currencySchema = z
   .object({
@@ -1057,6 +1100,7 @@ const characterSchema = z
     extraHitDice: z.array(extraHitDieSchema).catch([]),
     classResources: z.array(classResourceSchema).catch([]),
     proficiencies: proficienciesSchema,
+    proficiencyGrants: proficiencyGrantsSchema,
     currency: currencySchema,
     customCurrencies: z.array(customCurrencySchema).catch([]),
     inventory: z.array(inventoryItemSchema).catch([]),

--- a/app/features/character-sheet/model/constants.ts
+++ b/app/features/character-sheet/model/constants.ts
@@ -1004,6 +1004,44 @@ export const CUSTOM_BONUS_BASE_SOURCE_OPTIONS: Array<{
 ];
 
 /**
+ * Категории оружия справочника к группам владения листа. Словарь делит
+ * категории ещё и по дальнобойности, а правила — нет: обе половины воинского
+ * оружия дают одну и ту же группу. Огнестрельное (`FIREARM`, `FUTURISTIC`)
+ * своей группы на листе не имеет и не переводится.
+ */
+export const WEAPON_GROUP_BY_API_CATEGORY: Record<
+  string,
+  WeaponProficiencyGroup['key']
+> = {
+  SIMPLE_MELEE: 'simple',
+  SIMPLE_RANGED: 'simple',
+  MATERIAL_MELEE: 'martial',
+  MATERIAL_RANGED: 'martial',
+};
+
+/** Категории доспехов справочника к группам владения листа. */
+export const ARMOR_GROUP_BY_API_CATEGORY: Record<
+  string,
+  ArmorProficiencyGroup['key']
+> = {
+  LIGHT: 'light',
+  MEDIUM: 'medium',
+  HEAVY: 'heavy',
+  SHIELD: 'shields',
+};
+
+/**
+ * Начало идентификатора источника выдачи владений в журнале листа. Хвост —
+ * url класса, предыстории или вида либо идентификатор записи умения.
+ */
+export const PROFICIENCY_SOURCE_PREFIXES = {
+  class: 'class:',
+  background: 'background:',
+  species: 'species:',
+  feature: 'feature:',
+} as const;
+
+/**
  * Уровень взятия черты происхождения. По правилам 2024 предыстория даёт её на
  * первом уровне — независимо от того, на каком уровне игрок заполнил лист.
  */

--- a/app/features/character-sheet/model/mock.ts
+++ b/app/features/character-sheet/model/mock.ts
@@ -208,6 +208,9 @@ export const DEFAULT_CHARACTER: Character = {
     tools: [],
     languages: ['Общий'],
   },
+  // Общий язык нового листа выдан заготовкой, а не источником, поэтому в журнале
+  // его нет: снимать по нему нечего.
+  proficiencyGrants: [],
   currency: {
     copper: 0,
     silver: 0,

--- a/app/features/character-sheet/model/schemas.ts
+++ b/app/features/character-sheet/model/schemas.ts
@@ -16,6 +16,7 @@ import type {
   FeatSelectOption,
   FeatSummary,
   FeatureDescriptionNode,
+  GrantedProficiencies,
   InventoryArmor,
   InventoryWeapon,
   InventoryWeaponDamage,
@@ -31,7 +32,7 @@ import type {
   StartingEquipmentOption,
 } from './types';
 
-import { clamp } from 'es-toolkit';
+import { clamp, uniq } from 'es-toolkit';
 
 import { z } from '~/utils/zod';
 import { CasterType } from '~classes/model';
@@ -45,11 +46,15 @@ import {
   featModifiersSchema,
 } from './character-schema';
 import {
+  ARMOR_GROUP_BY_API_CATEGORY,
+  ARMOR_PROFICIENCY_GROUPS,
   CURRENCY_KEYS_BY_LABEL,
   INVENTORY_QUANTITY_MAX,
   SPELL_COMPONENT_LABELS,
   STARTING_EQUIPMENT_DEFAULT_COIN_KEY,
   STARTING_EQUIPMENT_LABELS,
+  WEAPON_GROUP_BY_API_CATEGORY,
+  WEAPON_PROFICIENCY_GROUPS,
 } from './constants';
 import {
   getClassToolChoice,
@@ -353,10 +358,85 @@ const featDetailSchema = z.object({
   category: z.string().catch(''),
   description: descriptionNodesSchema,
   mechanics: z
-    .object({ modifiers: featModifiersSchema })
+    .object({
+      modifiers: featModifiersSchema,
+      // Владения приходят категориями справочника — лист хранит их записями
+      // «вся группа», поэтому разбор ниже их переводит.
+      proficiencies: z
+        .object({
+          weaponCategories: z.array(z.string()).nullable().catch(null),
+          armorCategories: z.array(z.string()).nullable().catch(null),
+          tools: z
+            .array(
+              z.object({
+                url: z.string().catch(''),
+                name: z.string().catch(''),
+              }),
+            )
+            .nullable()
+            .catch(null),
+        })
+        .nullable()
+        .catch(null),
+    })
     .nullable()
     .catch(null),
 });
+
+/** Ответ справочника с владениями черты, как его разбирает схема детали. */
+type FeatProficienciesResponse = NonNullable<
+  NonNullable<z.infer<typeof featDetailSchema>['mechanics']>['proficiencies']
+>;
+
+/**
+ * Перевод владений черты из справочника в записи листа: категории оружия и
+ * доспехов становятся записями «вся группа» (одна на группу — обе половины
+ * воинского оружия дают одну запись), инструменты — владениями со ссылкой на
+ * предмет. Нераспознанные категории (огнестрельное — своей группы на листе нет)
+ * отбрасываются.
+ *
+ * @param proficiencies владения из механики черты.
+ * @returns владения в форме листа; null — черта ничего не выдаёт.
+ */
+function toGrantedProficiencies(
+  proficiencies: FeatProficienciesResponse,
+): GrantedProficiencies | null {
+  const weapons = uniq(
+    (proficiencies.weaponCategories ?? []).flatMap((category) => {
+      const key = WEAPON_GROUP_BY_API_CATEGORY[category];
+
+      const group = WEAPON_PROFICIENCY_GROUPS.find(
+        (candidate) => candidate.key === key,
+      );
+
+      return group ? [group.all] : [];
+    }),
+  );
+
+  const armor = uniq(
+    (proficiencies.armorCategories ?? []).flatMap((category) => {
+      const key = ARMOR_GROUP_BY_API_CATEGORY[category];
+
+      const group = ARMOR_PROFICIENCY_GROUPS.find(
+        (candidate) => candidate.key === key,
+      );
+
+      return group ? [group.all] : [];
+    }),
+  );
+
+  // Инструмент без названия показать нечем, а без ссылки — можно: у своих
+  // инструментов её и не бывает.
+  const tools = (proficiencies.tools ?? []).flatMap((tool) =>
+    tool.name ? [{ name: tool.name, url: tool.url || null }] : [],
+  );
+
+  if (!weapons.length && !armor.length && !tools.length) {
+    return null;
+  }
+
+  return { armor, weapons, tools, languages: [] };
+}
 
 /**
  * Валидация детального ответа `GET /api/v2/feats/{url}`.
@@ -371,12 +451,15 @@ export function parseFeatDetail(input: unknown): FeatSummary | null {
     return null;
   }
 
+  const proficiencies = result.data.mechanics?.proficiencies;
+
   return {
     url: result.data.url,
     name: result.data.name.rus,
     category: result.data.category,
     description: result.data.description,
     modifiers: result.data.mechanics?.modifiers ?? null,
+    proficiencies: proficiencies ? toGrantedProficiencies(proficiencies) : null,
   };
 }
 

--- a/app/features/character-sheet/model/types.ts
+++ b/app/features/character-sheet/model/types.ts
@@ -669,6 +669,38 @@ export interface CharacterProficiencies {
   languages: string[];
 }
 
+/**
+ * Набор владений, выданный источником. Мастерство оружием сюда не входит: его
+ * выдают отдельные умения по одному виду, а не наборами.
+ */
+export interface GrantedProficiencies {
+  armor: string[];
+  weapons: string[];
+  tools: CharacterToolProficiency[];
+  languages: string[];
+}
+
+/**
+ * Запись журнала выдач: что именно выдал один источник. По ней снятие класса,
+ * предыстории, вида или черты забирает ровно своё и не трогает ни чужого, ни
+ * отмеченного игроком вручную.
+ *
+ * Устроено как `health.levelGains`: общий журнал листа с пометкой источника, а не
+ * запись на самой сущности. Источников четыре, а журнал один — так снятие любого
+ * из них считается одинаково.
+ *
+ * У листов, сохранённых до появления журнала, записей нет: там всё считается
+ * отмеченным вручную и не снимается — ровно прежнее поведение.
+ */
+export interface ProficiencyGrant extends GrantedProficiencies {
+  /**
+   * Кто выдал: `class:<url>`, `background:<url>`, `species:<url>` либо
+   * `feature:<id>` (у черты — идентификатор её записи, поэтому копии
+   * повторяемой черты снимаются независимо).
+   */
+  source: string;
+}
+
 /** Ключ группы владений персонажа. */
 export type ProficiencyGroupKey = keyof CharacterProficiencies;
 
@@ -1041,6 +1073,13 @@ export interface CharacterFeature {
    * особенностей вида, класса и заведённых вручную — им двигать лист нечем.
    */
   modifiers?: CharacterFeatureModifiers | null;
+
+  /**
+   * Владения, которые черта выдаёт без выбора; null — не выдаёт. Снимок, как и
+   * `modifiers`: по нему сверка ведёт запись журнала выдач, а снятие черты
+   * забирает ровно выданное.
+   */
+  proficiencies?: GrantedProficiencies | null;
 }
 
 /** Отбор особенностей на вкладке особенностей. */
@@ -1083,6 +1122,13 @@ export interface FeatSummary {
    * не двигает либо механика у записи каталога не заполнена.
    */
   modifiers: CharacterFeatureModifiers | null;
+
+  /**
+   * Владения из `mechanics.proficiencies`, уже приведённые к справочнику листа
+   * (категории справочника — к записям вида «Всё воинское оружие»); null —
+   * черта владений не выдаёт.
+   */
+  proficiencies: GrantedProficiencies | null;
 }
 
 /** Заклинание в книге персонажа (и опция поиска заклинаний). */
@@ -2654,6 +2700,14 @@ export interface Character {
   classResources: CharacterClassResource[];
 
   proficiencies: CharacterProficiencies;
+
+  /**
+   * Журнал выдач владений: кто и что выдал. Сами владения лежат в
+   * `proficiencies` одним списком — журнал нужен только затем, чтобы снятие
+   * источника забрало ровно своё.
+   */
+  proficiencyGrants: ProficiencyGrant[];
+
   currency: CharacterCurrency;
 
   /** Пользовательские денежные единицы (сверх пяти стандартных). */

--- a/app/features/character-sheet/model/utils.ts
+++ b/app/features/character-sheet/model/utils.ts
@@ -32,6 +32,7 @@ import type {
   CharacterInventoryItem,
   CharacterLevelHitPoints,
   CharacterPersonality,
+  CharacterProficiencies,
   CharacterSavingThrow,
   CharacterSettings,
   CharacterSkill,
@@ -69,6 +70,7 @@ import type {
   FeatureOrigin,
   FeatureOriginGroup,
   FeatureTabFilter,
+  GrantedProficiencies,
   GrantedStartingEquipment,
   HitDiceAmount,
   HitDicePool,
@@ -97,6 +99,7 @@ import type {
   PreparedSpellsScaling,
   PrimarySpeed,
   ProficiencyCatalogGroup,
+  ProficiencyGrant,
   ResourceRecovery,
   ResourceRecoveryMode,
   ResourceRecoveryRule,
@@ -127,7 +130,14 @@ import type {
   WeaponDamage,
 } from './types';
 
-import { capitalize, clamp, mapValues, round, upperFirst } from 'es-toolkit';
+import {
+  capitalize,
+  clamp,
+  mapValues,
+  round,
+  union,
+  upperFirst,
+} from 'es-toolkit';
 
 import { LEVELS } from '~/shared/consts';
 import {
@@ -290,6 +300,7 @@ import {
   PREPARED_SPELLS_MAX,
   PREPARED_SPELLS_MIN,
   PREPARED_SPELLS_VALUE_SEPARATOR,
+  PROFICIENCY_SOURCE_PREFIXES,
   RESOURCE_CHARGE_FORMS,
   RESOURCE_COUNT_MAX,
   RESOURCE_RECOVERY_ALL_LABEL,
@@ -6300,7 +6311,200 @@ export function buildFeatFeature(
     level,
     choice: null,
     modifiers: summary.modifiers,
+    proficiencies: summary.proficiencies,
   };
+}
+
+/**
+ * Владения всех выдач одним набором: по нему считается, что на листе держится
+ * выдачами, а что отмечено игроком вручную.
+ *
+ * @param grants записи журнала выдач.
+ * @returns объединение выданного по группам; инструменты — по названиям.
+ */
+function collectGrantedProficiencies(grants: ProficiencyGrant[]): {
+  armor: Set<string>;
+  weapons: Set<string>;
+  tools: Set<string>;
+  languages: Set<string>;
+} {
+  return {
+    armor: new Set(grants.flatMap((grant) => grant.armor)),
+    weapons: new Set(grants.flatMap((grant) => grant.weapons)),
+    // Инструменты сверяются по названию: ссылка на предмет у одной и той же
+    // записи бывает и заполненной, и пустой (свой инструмент игрока).
+    tools: new Set(
+      grants.flatMap((grant) => grant.tools.map(({ name }) => name)),
+    ),
+    languages: new Set(grants.flatMap((grant) => grant.languages)),
+  };
+}
+
+/**
+ * Приведение владений листа к новому журналу выдач: то, что перестал давать
+ * хоть кто-то, снимается — но только если этого не даёт никто из оставшихся;
+ * новое добавляется без дублей.
+ *
+ * Отмеченное игроком вручную не трогается: его в журнале нет, а снимается
+ * только то, что там записано. Обратная сторона — владение, которое игрок
+ * отметил сам, а потом ровно то же выдал класс или черта, уйдёт вместе с ними:
+ * различить эти два случая по одному списку нельзя. Ровно тот же размен уже
+ * сделан у выданного снаряжения ({@link applyStartingEquipmentChange}).
+ *
+ * @param proficiencies владения персонажа.
+ * @param previous журнал выдач до изменения.
+ * @param next журнал выдач после изменения.
+ * @returns владения, согласованные с новым журналом.
+ */
+export function applyProficiencyGrants(
+  proficiencies: CharacterProficiencies,
+  previous: ProficiencyGrant[],
+  next: ProficiencyGrant[],
+): CharacterProficiencies {
+  const before = collectGrantedProficiencies(previous);
+  const after = collectGrantedProficiencies(next);
+
+  return {
+    ...proficiencies,
+    armor: union(dropRevoked(proficiencies.armor, before.armor, after.armor), [
+      ...after.armor,
+    ]),
+    weapons: union(
+      dropRevoked(proficiencies.weapons, before.weapons, after.weapons),
+      [...after.weapons],
+    ),
+    tools: unionToolProficiencies(
+      proficiencies.tools.filter((tool) =>
+        isKeptProficiency(tool.name, before.tools, after.tools),
+      ),
+      next.flatMap((grant) => grant.tools),
+    ),
+    languages: union(
+      dropRevoked(proficiencies.languages, before.languages, after.languages),
+      [...after.languages],
+    ),
+  };
+}
+
+/**
+ * Держится ли владение на листе после смены журнала: то, чего не выдавал никто,
+ * отмечено игроком и остаётся; выданное — только пока его даёт хоть кто-то.
+ *
+ * @param key название владения (у инструментов — их название).
+ * @param before выданное до изменения.
+ * @param after выданное после изменения.
+ * @returns true — владение остаётся на листе.
+ */
+function isKeptProficiency(
+  key: string,
+  before: Set<string>,
+  after: Set<string>,
+): boolean {
+  return !before.has(key) || after.has(key);
+}
+
+/**
+ * Список владений без тех, что перестали выдаваться.
+ *
+ * @param items владения группы.
+ * @param before выданное до изменения.
+ * @param after выданное после изменения.
+ * @returns владения, оставшиеся на листе.
+ */
+function dropRevoked(
+  items: string[],
+  before: Set<string>,
+  after: Set<string>,
+): string[] {
+  return items.filter((item) => isKeptProficiency(item, before, after));
+}
+
+/**
+ * Журнал выдач, подрезанный по владениям листа: из записей уходит то, чего на
+ * листе больше нет.
+ *
+ * Нужно после ручной правки владений. Игрок снял галочку с выданного владения —
+ * значит он его не хочет; оставь запись в журнале, и владение вернулось бы при
+ * ближайшей смене класса или черты, потому что сверка добавляет всё выданное.
+ * Опустевшие записи выпадают целиком.
+ *
+ * @param grants журнал выдач листа.
+ * @param proficiencies владения персонажа после правки.
+ * @returns журнал без того, чего на листе не осталось.
+ */
+export function pruneProficiencyGrants(
+  grants: ProficiencyGrant[],
+  proficiencies: CharacterProficiencies,
+): ProficiencyGrant[] {
+  const armor = new Set(proficiencies.armor);
+  const weapons = new Set(proficiencies.weapons);
+  const languages = new Set(proficiencies.languages);
+  const tools = new Set(proficiencies.tools.map(({ name }) => name));
+
+  return grants.flatMap((grant) => {
+    const pruned: ProficiencyGrant = {
+      source: grant.source,
+      armor: grant.armor.filter((item) => armor.has(item)),
+      weapons: grant.weapons.filter((item) => weapons.has(item)),
+      tools: grant.tools.filter((tool) => tools.has(tool.name)),
+      languages: grant.languages.filter((item) => languages.has(item)),
+    };
+
+    return hasGrantedProficiencies(pruned) ? [pruned] : [];
+  });
+}
+
+/**
+ * Идентификатор источника выдачи для журнала владений.
+ *
+ * @param kind вид источника.
+ * @param key url класса, предыстории или вида либо идентификатор записи умения.
+ * @returns идентификатор источника.
+ */
+export function getProficiencySourceId(
+  kind: keyof typeof PROFICIENCY_SOURCE_PREFIXES,
+  key: string,
+): string {
+  return `${PROFICIENCY_SOURCE_PREFIXES[kind]}${key}`;
+}
+
+/**
+ * Журнал выдач с обновлённой записью источника: прежняя запись заменяется, а
+ * пустая выдача (источник ушёл или ничего не даёт) запись убирает.
+ *
+ * @param grants журнал выдач листа.
+ * @param source идентификатор источника.
+ * @param granted выданные владения; null — источник ничего не выдаёт.
+ * @returns новый журнал выдач.
+ */
+export function withProficiencyGrant(
+  grants: ProficiencyGrant[],
+  source: string,
+  granted: GrantedProficiencies | null,
+): ProficiencyGrant[] {
+  const others = grants.filter((grant) => grant.source !== source);
+
+  if (!granted || !hasGrantedProficiencies(granted)) {
+    return others;
+  }
+
+  return [...others, { ...granted, source }];
+}
+
+/**
+ * Есть ли в наборе хоть одно владение: пустые записи в журнал не попадают —
+ * снимать по ним нечего.
+ *
+ * @param granted набор выданных владений.
+ * @returns true — набор не пуст.
+ */
+function hasGrantedProficiencies(granted: GrantedProficiencies): boolean {
+  return Boolean(
+    granted.armor.length
+    || granted.weapons.length
+    || granted.tools.length
+    || granted.languages.length,
+  );
 }
 
 /**
@@ -6548,14 +6752,45 @@ function withFeatInitiativeBonuses(
 }
 
 /**
+ * Записи журнала выдач от черт листа: по записи на каждую черту со снимком
+ * владений. Как и свои бонусы инициативы, пересобираются целиком — записи
+ * прочих источников (класс, предыстория, вид) остаются нетронутыми.
+ *
+ * @param grants журнал выдач листа.
+ * @param features особенности листа.
+ * @returns журнал, согласованный с чертами.
+ */
+function withFeatProficiencyGrants(
+  grants: ProficiencyGrant[],
+  features: CharacterFeature[],
+): ProficiencyGrant[] {
+  const others = grants.filter(
+    (grant) => !grant.source.startsWith(PROFICIENCY_SOURCE_PREFIXES.feature),
+  );
+
+  const fromFeatures = features.flatMap<ProficiencyGrant>((feature) =>
+    feature.proficiencies
+      ? [
+          {
+            ...feature.proficiencies,
+            source: `${PROFICIENCY_SOURCE_PREFIXES.feature}${feature.id}`,
+          },
+        ]
+      : [],
+  );
+
+  return [...others, ...fromFeatures];
+}
+
+/**
  * Доведение листа до нового набора черт и уровня.
  *
  * Постоянные модификаторы черт лист хранит по-разному, и сверка нужна не всем.
  * КД и скорости считаются на лету — там слагаемое от черт появляется само.
  * Максимум хитов, наоборот, хранится числом и правится игроком вручную, поэтому
  * его прибавка ведётся разницей: иначе пересчёт уровней или смена класса затёрли
- * бы её, а повторное применение начислило бы дважды. Свои бонусы инициативы
- * пересобираются целиком — эта часть сверки идемпотентна.
+ * бы её, а повторное применение начислило бы дважды. Свои бонусы инициативы и
+ * записи журнала выдач пересобираются целиком — эти части сверки идемпотентны.
  *
  * Вызывать нужно везде, где меняется список особенностей или уровень.
  *
@@ -6567,6 +6802,11 @@ export function withFeatModifiers(
   next: Character,
   previous: Pick<Character, 'features' | 'level'>,
 ): Character {
+  const proficiencyGrants = withFeatProficiencyGrants(
+    next.proficiencyGrants,
+    next.features,
+  );
+
   return {
     ...next,
     health: applyFeatHitPoints(next.health, previous, next),
@@ -6577,6 +6817,14 @@ export function withFeatModifiers(
         next.features,
       ),
     },
+    proficiencyGrants,
+    // Прежний журнал ещё лежит в `next`: черты уже сменились, а записи — нет,
+    // поэтому он и служит состоянием «до».
+    proficiencies: applyProficiencyGrants(
+      next.proficiencies,
+      next.proficiencyGrants,
+      proficiencyGrants,
+    ),
   };
 }
 

--- a/app/features/feats/editor/FeatsEditor.vue
+++ b/app/features/feats/editor/FeatsEditor.vue
@@ -20,6 +20,7 @@
     FeatChoices,
     FeatModifiers,
     FeatPrerequisiteFields,
+    FeatProficiencies,
   } from './ui';
 
   const formRef = useTemplateRef('formRef');
@@ -168,6 +169,14 @@
       </template>
 
       <FeatModifiers v-model="mechanics.modifiers" />
+    </UCard>
+
+    <UCard variant="subtle">
+      <template #header>
+        <h2 class="truncate text-base text-highlighted">Выдаваемые владения</h2>
+      </template>
+
+      <FeatProficiencies v-model="mechanics.proficiencies" />
     </UCard>
 
     <UCard variant="subtle">

--- a/app/features/feats/editor/ui/FeatPrerequisiteFields.vue
+++ b/app/features/feats/editor/ui/FeatPrerequisiteFields.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import type { FeatEntityRef, FeatPrerequisiteDetails } from '../../model';
+  import type { FeatPrerequisiteDetails } from '../../model';
 
   import {
     SelectArmorCategory,
@@ -12,43 +12,32 @@
   import {
     CLASS_FEATURE_REQUIREMENT_OPTIONS,
     createAbilityRequirement,
+    toEntityRefs,
+    toEntityRefUrls,
+    toUrlList,
   } from '../../model';
   import FeatAbilityRequirements from './FeatAbilityRequirements.vue';
-
-  /** Селекты справочников отдают url'ы, а core-api ждёт ссылки `{ url }`. */
-  function toUrls(refs: Array<FeatEntityRef>): Array<string> {
-    return refs.map((reference) => reference.url);
-  }
-
-  function toRefs(urls: Array<string>): Array<FeatEntityRef> {
-    return urls.map((url) => ({ url }));
-  }
-
-  /** Селект отдаёт либо один url, либо список — приводим к списку. */
-  function normalizeUrls(value: string | Array<string>): Array<string> {
-    return Array.isArray(value) ? value : [value];
-  }
 
   const model = defineModel<FeatPrerequisiteDetails>({ required: true });
 
   const featUrls = computed<string | Array<string>>({
-    get: () => toUrls(model.value.feats),
+    get: () => toEntityRefUrls(model.value.feats),
     set: (value) => {
-      model.value = { ...model.value, feats: toRefs(normalizeUrls(value)) };
+      model.value = { ...model.value, feats: toEntityRefs(toUrlList(value)) };
     },
   });
 
   const classUrls = computed<string | Array<string>>({
-    get: () => toUrls(model.value.classes),
+    get: () => toEntityRefUrls(model.value.classes),
     set: (value) => {
-      model.value = { ...model.value, classes: toRefs(normalizeUrls(value)) };
+      model.value = { ...model.value, classes: toEntityRefs(toUrlList(value)) };
     },
   });
 
   const speciesUrls = computed<string | Array<string>>({
-    get: () => toUrls(model.value.species),
+    get: () => toEntityRefUrls(model.value.species),
     set: (value) => {
-      model.value = { ...model.value, species: toRefs(normalizeUrls(value)) };
+      model.value = { ...model.value, species: toEntityRefs(toUrlList(value)) };
     },
   });
 
@@ -58,7 +47,7 @@
     set: (value) => {
       model.value = {
         ...model.value,
-        backgrounds: value ? toRefs([value]) : [],
+        backgrounds: value ? toEntityRefs([value]) : [],
       };
     },
   });

--- a/app/features/feats/editor/ui/FeatProficiencies.vue
+++ b/app/features/feats/editor/ui/FeatProficiencies.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+  import type { FeatProficiencyGrant } from '../../model';
+
+  import {
+    SelectArmorCategory,
+    SelectItem,
+    SelectWeaponCategory,
+  } from '~ui/select';
+
+  import { toEntityRefs, toEntityRefUrls, toUrlList } from '../../model';
+
+  const model = defineModel<FeatProficiencyGrant>({ required: true });
+
+  const weaponCategories = computed<string | Array<string>>({
+    get: () => model.value.weaponCategories,
+    set: (value) => {
+      model.value = { ...model.value, weaponCategories: toUrlList(value) };
+    },
+  });
+
+  const armorCategories = computed<string | Array<string>>({
+    get: () => model.value.armorCategories,
+    set: (value) => {
+      model.value = { ...model.value, armorCategories: toUrlList(value) };
+    },
+  });
+
+  const toolUrls = computed<string | Array<string>>({
+    get: () => toEntityRefUrls(model.value.tools),
+    set: (value) => {
+      model.value = { ...model.value, tools: toEntityRefs(toUrlList(value)) };
+    },
+  });
+</script>
+
+<template>
+  <div class="grid grid-cols-1 gap-4 md:grid-cols-24">
+    <p class="text-sm text-dimmed md:col-span-full">
+      Только то, что черта выдаёт без выбора. Если игрок выбирает — навык,
+      инструмент, вид оружия — заводите выбор, а не выдачу.
+    </p>
+
+    <UFormField
+      class="md:col-span-12"
+      label="Оружие"
+      help="Воинское оружие — это обе категории: рукопашное и дальнобойное"
+    >
+      <SelectWeaponCategory
+        v-model="weaponCategories"
+        multiple
+      />
+    </UFormField>
+
+    <UFormField
+      class="md:col-span-12"
+      label="Доспехи"
+    >
+      <SelectArmorCategory
+        v-model="armorCategories"
+        multiple
+      />
+    </UFormField>
+
+    <UFormField
+      class="md:col-span-full"
+      label="Инструменты"
+    >
+      <SelectItem
+        v-model="toolUrls"
+        multiple
+      />
+    </UFormField>
+  </div>
+</template>

--- a/app/features/feats/editor/ui/index.ts
+++ b/app/features/feats/editor/ui/index.ts
@@ -3,3 +3,4 @@ export { default as FeatAbilityRequirements } from './FeatAbilityRequirements.vu
 export { default as FeatChoices } from './FeatChoices.vue';
 export { default as FeatModifiers } from './FeatModifiers.vue';
 export { default as FeatPrerequisiteFields } from './FeatPrerequisiteFields.vue';
+export { default as FeatProficiencies } from './FeatProficiencies.vue';

--- a/app/features/feats/model/mechanics.ts
+++ b/app/features/feats/model/mechanics.ts
@@ -164,11 +164,69 @@ export interface FeatModifiers {
   initiativeProficiencyBonus: boolean;
 }
 
+/**
+ * Владения, которые черта выдаёт сразу и целиком: «Вы получаете владение
+ * воинским оружием». Выбираемые владения сюда не идут — у них есть количество и
+ * пул значений, поэтому они живут в {@link FeatChoice}.
+ *
+ * Навыков, спасбросков и языков здесь нет: первые два черты выдают выбором, а
+ * справочник языков сайта и словарь языков листа пока расходятся в названиях и
+ * группировке.
+ */
+export interface FeatProficiencyGrant {
+  /** Категории оружия справочника (`MATERIAL_MELEE` и подобные). */
+  weaponCategories: Array<string>;
+
+  /** Категории доспехов справочника (`MEDIUM`, `SHIELD`). */
+  armorCategories: Array<string>;
+
+  /** Инструменты из раздела «Предметы». */
+  tools: Array<FeatEntityRef>;
+}
+
 /** Механика черты целиком. */
 export interface FeatMechanics {
   abilityBonuses: Array<FeatAbilityBonus>;
   choices: Array<FeatChoice>;
   modifiers: FeatModifiers;
+  proficiencies: FeatProficiencyGrant;
+}
+
+/**
+ * Ссылки на сущности к списку url: селекты справочников хранят только их.
+ *
+ * @param refs ссылки на сущности.
+ * @returns url сущностей.
+ */
+export function toEntityRefUrls(refs: Array<FeatEntityRef>): Array<string> {
+  return refs.map((reference) => reference.url);
+}
+
+/**
+ * Url к ссылкам: core-api ждёт `{ url }`, а название подставится при следующей
+ * загрузке черты — снимок имени форме не нужен.
+ *
+ * @param urls url сущностей.
+ * @returns ссылки на сущности.
+ */
+export function toEntityRefs(urls: Array<string>): Array<FeatEntityRef> {
+  return urls.map((url) => ({ url }));
+}
+
+/**
+ * Значение селекта к списку: одиночный выбор приходит строкой, пустой — ничем.
+ *
+ * @param value значение селекта.
+ * @returns выбранные значения списком.
+ */
+export function toUrlList(
+  value: string | Array<string> | undefined,
+): Array<string> {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  return value ? [value] : [];
 }
 
 /** Новый вариант повышения характеристик. */
@@ -274,11 +332,21 @@ export function createFeatModifiers(): FeatModifiers {
   };
 }
 
+/** Пустая выдача владений. */
+export function createFeatProficiencyGrant(): FeatProficiencyGrant {
+  return {
+    weaponCategories: [],
+    armorCategories: [],
+    tools: [],
+  };
+}
+
 /** Пустая механика черты. */
 export function createFeatMechanics(): FeatMechanics {
   return {
     abilityBonuses: [],
     choices: [],
     modifiers: createFeatModifiers(),
+    proficiencies: createFeatProficiencyGrant(),
   };
 }

--- a/app/features/feats/model/schema.ts
+++ b/app/features/feats/model/schema.ts
@@ -120,10 +120,17 @@ const modifiersSchema = z.object({
   initiativeProficiencyBonus: z.boolean().optional(),
 });
 
+const proficiencyGrantSchema = z.object({
+  weaponCategories: z.array(z.string()).optional(),
+  armorCategories: z.array(z.string()).optional(),
+  tools: z.array(entityRefSchema).optional(),
+});
+
 const mechanicsSchema = z.object({
   abilityBonuses: z.array(abilityBonusSchema).optional(),
   choices: z.array(choiceSchema).optional(),
   modifiers: modifiersSchema.optional(),
+  proficiencies: proficiencyGrantSchema.optional(),
 });
 
 const prerequisiteDetailsSchema = z.object({

--- a/app/features/feats/model/transform.ts
+++ b/app/features/feats/model/transform.ts
@@ -5,6 +5,7 @@ import type {
   FeatMechanics,
   FeatModifiers,
   FeatPrerequisiteDetails,
+  FeatProficiencyGrant,
   FeatSpellFilter,
 } from './mechanics';
 
@@ -100,12 +101,24 @@ function buildModifiers(modifiers: FeatModifiers): FeatModifiers | undefined {
   });
 }
 
+/** Готовит выдаваемые владения: инструмент без ссылки отправлять некуда. */
+function buildProficiencies(
+  proficiencies: FeatProficiencyGrant,
+): FeatProficiencyGrant | undefined {
+  return orUndefined({
+    ...proficiencies,
+    tools: proficiencies.tools.filter((tool) => !!text(tool.url)),
+  });
+}
+
 /** Готовит механику целиком. */
 function buildMechanics(mechanics: FeatMechanics): FeatMechanics | undefined {
   return orUndefined({
     abilityBonuses: buildAbilityBonuses(mechanics.abilityBonuses),
     choices: buildChoices(mechanics.choices),
     modifiers: buildModifiers(mechanics.modifiers) ?? mechanics.modifiers,
+    proficiencies:
+      buildProficiencies(mechanics.proficiencies) ?? mechanics.proficiencies,
   });
 }
 


### PR DESCRIPTION
Лист не помнил, кто выдал владение. Прямая цитата из `removeClass`:

> Владения, навыки и языки, однажды выданные классом, остаются — лист не помнит, кто их дал, а снимать чужое опаснее, чем оставить лишнее.

Из-за этого снятие класса оставляло его владения навсегда, а выдать владение чертой было нечем. Здесь появляется учёт источника — и на нём же работает выдача от черт.

Стоит на #391 — сначала он. Требует core-api#339.

## Журнал выдач

`character.proficiencyGrants` — запись на источник с пометкой, кто он: `class:<url>`, `background:<url>`, `species:<url>`, `feature:<id>`. Снятие любого из них забирает ровно записанное за ним — и только если того же не даёт кто-то ещё.

Устроено как `health.levelGains`: общий журнал листа с ключом источника, а не запись на самой сущности (как у `startingEquipment`). Источников четыре, а журнал один — так снятие любого считается одинаково.

Подключены все четыре: класс (выбор, смена, удаление), второй класс мультикласса, предыстория, вид, черты. Выдача от черт въехала в существующую сверку `withFeatModifiers` — идемпотентно, как свои бонусы инициативы.

## Миграция

Её нет, и намеренно. У сохранённых листов журнал пуст — значит все владения считаются отмеченными вручную и не снимаются, то есть ровно прежнее поведение. Записи появятся по мере того, как игрок заново выберет класс, предысторию или вид.

## Размен, встроенный в приём

Владение, которое игрок отметил сам, а потом ровно то же выдал источник, уйдёт вместе с ним: по одному списку эти два случая не различить. Тот же размен уже сделан у выданного снаряжения (`applyStartingEquipmentChange`). Различать — значит хранить источники поштучно у каждого владения и переписывать панель с тремя модалками.

Обратный случай закрыт: если игрок снимет галочку с выданного владения, оно уходит и из журнала (`pruneProficiencyGrants`), иначе вернулось бы при ближайшей смене класса или черты.

## Черты

`mechanics.proficiencies` из справочника кладётся в запись умения снимком и переводится в записи листа: обе половины воинского оружия дают одну запись «Всё воинское оружие», огнестрельное своей группы на листе не имеет и отбрасывается. В редакторе черты — раздел «Выдаваемые владения» на готовых `SelectWeaponCategory` / `SelectArmorCategory` / `SelectItem`.

## Что осталось за рамками

Навыки и спасброски в журнал не идут: они хранятся не списком владений, а записями с уровнем владения и флагом, и выдаются своим путём. У них та же проблема источника — это отдельная задача.

Языки, выбранные в умениях при повышении уровня, тоже вне журнала: мастер собирает их со всех классов разом и не говорит, чей это выбор. Такой язык остаётся навсегда — как было и до журнала. Отмечено комментарием на месте.

## Попутно

`toUrls` / `toRefs` / `normalizeUrls` дублировались бы между формой предусловия и новой формой владений — вынесены в `~feats/model` как `toEntityRefUrls` / `toEntityRefs` / `toUrlList`, обе формы переведены на них.

## Проверено

15 утверждений против настоящих функций модели: выдача и снятие, своё владение игрока не трогается, два источника на одно владение, повторное применение не двоит, лист без журнала, снятие галочки игроком (не возвращается), разбор детали черты. `lint`, `type-check`, `stylelint` — чисто.
